### PR TITLE
🤦 d'oh fix catch 22 with validating openapi

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -57,7 +57,7 @@ groups = {
 resources = []
 
 # isCI comes from tests/integration/Tiltfile
-isCI = False
+isCI = os.environ.get("ALPINE_VERSION", False)
 
 for arg in cfg.get("to-run", []):
     if arg == "integration-test":

--- a/containers/attributes/Dockerfile
+++ b/containers/attributes/Dockerfile
@@ -25,6 +25,8 @@ RUN python3 -m compileall attributes/
 
 # Validate openapi
 COPY attributes/openapi.json attributes/
+
+FROM build AS validate-openapi
 RUN diff <(python3 -m attributes.main) attributes/openapi.json
 
 # stage - production server

--- a/containers/claims/Dockerfile
+++ b/containers/claims/Dockerfile
@@ -24,6 +24,8 @@ RUN python3 -m compileall .
 
 # Validate openapi
 COPY claims/openapi.json claims/
+
+FROM build AS validate-openapi
 RUN diff <(python3 -m claims.main) claims/openapi.json
 
 # stage - production server

--- a/containers/entitlements/Dockerfile
+++ b/containers/entitlements/Dockerfile
@@ -25,6 +25,8 @@ RUN python3 -m compileall .
 
 # Validate openapi
 COPY entitlements/openapi.json entitlements/
+
+FROM build AS validate-openapi
 RUN diff <(python3 -m entitlements.main) entitlements/openapi.json
 
 # stage - production server

--- a/containers/python_base/scripts/openapi-generator
+++ b/containers/python_base/scripts/openapi-generator
@@ -25,6 +25,7 @@ if ! docker build \
   --build-arg ALPINE_VERSION=${ALPINE_VERSION} \
   --build-arg PY_VERSION=${PY_VERSION} \
   --file containers/python_base/Dockerfile \
+  --target build \
   ./containers/python_base; then
   monolog ERROR "Failed to build python_base container"
   exit 1

--- a/deployments/docker-desktop/claims-values.yaml
+++ b/deployments/docker-desktop/claims-values.yaml
@@ -1,6 +1,14 @@
+autoscaling:
+  enabled: false
+nameOverride: opentdf-claims
 postgres:
   host: opentdf-postgresql
   port: 5432
   user: tdf_entitlement_reader
   database: tdf_database
-  schema: tdf_attribute
+  schema: tdf_entitlement
+replicaCount: 1
+secretRef:
+  name: claims-secrets
+serviceAccount:
+  create: true

--- a/deployments/docker-desktop/keycloak-values.yaml
+++ b/deployments/docker-desktop/keycloak-values.yaml
@@ -18,7 +18,7 @@ extraEnv: |
   - name: KEYCLOAK_PASSWORD
     value: mykeycloakpassword
   - name: CLAIMS_URL
-    value: http://opentdf-claims:5000/v1/claims
+    value: http://opentdf-claims:5000/claims
   - name: DB_VENDOR
     value: postgres
   - name: DB_ADDR

--- a/tests/containers/clients/py/decrypt.py
+++ b/tests/containers/clients/py/decrypt.py
@@ -51,7 +51,7 @@ def main():
     auth = args.auth.split(":")
 
     oidc_creds = OIDCCredentials()
-    oidc_creds.set_client_credentials(
+    oidc_creds.set_client_credentials_client_secret(
         client_id=auth[1],
         client_secret=auth[2],
         organization_name=auth[0],

--- a/tests/containers/clients/py/encrypt.py
+++ b/tests/containers/clients/py/encrypt.py
@@ -59,7 +59,7 @@ def main():
     attributes = args.attributes.split(",") if args.attributes else []
 
     oidc_creds = OIDCCredentials()
-    oidc_creds.set_client_credentials(
+    oidc_creds.set_client_credentials_client_secret(
         client_id=auth[1],
         client_secret=auth[2],
         organization_name=auth[0],

--- a/tests/integration/keycloak-pki-values.yaml
+++ b/tests/integration/keycloak-pki-values.yaml
@@ -13,7 +13,7 @@ extraEnv: |
   - name: KEYCLOAK_PASSWORD
     value: mykeycloakpassword
   - name: CLAIMS_URL
-    value: http://opentdf-claims:5000/v1/claims
+    value: http://opentdf-claims:5000/claims
   - name: DB_VENDOR
     value: postgres
   - name: DB_ADDR


### PR DESCRIPTION
- You need the dockerized images to build the openapi
- but I added a validation check to the Dockerfile which fails the build if the openapi file is out of date
- so this adds a new layer, validate-openapi, and uses the previous layer, build, for generating the openapi
- Also fixes out-of-date opentdf python library method names
- And a few issues related to claims in local development