### PR TITLE
Sync SQL schema with changes introduced in #134

### DIFF
--- a/containers/migration/schema.sql
+++ b/containers/migration/schema.sql
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS tdf_attribute.attribute
     rule         VARCHAR NOT NULL,
     name         VARCHAR NOT NULL UNIQUE, -- ??? COLLATE NOCASE
     description  VARCHAR,
-    values       TEXT[]
+    values_array       TEXT[]
 );
 
 CREATE SCHEMA IF NOT EXISTS tdf_entitlement;

--- a/deployments/docker-desktop/tdf-postgresql-values.yaml
+++ b/deployments/docker-desktop/tdf-postgresql-values.yaml
@@ -43,7 +43,7 @@ initdbScripts:
         rule         VARCHAR NOT NULL,
         name         VARCHAR NOT NULL UNIQUE, -- ??? COLLATE NOCASE
         description  VARCHAR,
-        values       TEXT[]
+        values_array TEXT[]
     );
 
     CREATE SCHEMA IF NOT EXISTS tdf_entitlement;

--- a/deployments/local/values-postgresql-tdf.yaml
+++ b/deployments/local/values-postgresql-tdf.yaml
@@ -40,7 +40,7 @@ initdbScripts:
         rule         VARCHAR NOT NULL,
         name         VARCHAR NOT NULL UNIQUE, -- ??? COLLATE NOCASE
         description  VARCHAR,
-        values       TEXT[]
+        values_array TEXT[]
     );
 
     CREATE SCHEMA IF NOT EXISTS tdf_entitlement;


### PR DESCRIPTION
#134 changed `tdf_attributes.attributes.value` -> `tdf_attributes.attributes.value_array`, but not all DB init scripts were synced with that change.


### Checklist

- [x] I have added or updated unit tests and run them via `scripts/monotest all`
- [x] I have added or updated E2E cluster tests and run them via `kubectl kuttl test tests/cluster'
- [x] I have added or updated integration tests in `xtest` (if appropriate)
- [x] I have added or updated documentation / readme (if appropriate)
- [x] I have verified that my changes have not introduced new lint errors
- [x] I have updated the change log

### Testing Instructions
