### PR TITLE
Ensure specific published charts are locked to specific published image version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -177,7 +177,8 @@ jobs:
           for d in */ ; do
               if [ -f "$d/Chart.yaml" ]; then
                 echo "Rendering Helm chart $d to validate defaults..."
-                helm package $d
+                helm package $d --app-version ${GITHUB_SHA::7}
+                echo "Packaged Helm chart $d with appVersion (e.g. container tag) baked to ${GITHUB_SHA::7}"
                 echo *.tgz
                 helm push *.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
                 rm *.tgz

--- a/charts/attributes/Chart.yaml
+++ b/charts/attributes/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 maintainers:
   - name: Virtru
 icon: https://avatars.githubusercontent.com/u/90051847?s=200&v=4
-appVersion: "0.0.1"
+appVersion: "main"

--- a/charts/attributes/templates/deployment.yaml
+++ b/charts/attributes/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.image }}"
+          image: {{ .Values.image.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             {{- with .Values.secretRef }}

--- a/charts/attributes/values.yaml
+++ b/charts/attributes/values.yaml
@@ -28,7 +28,9 @@ oidc:
 image:
   # The image selector, also called the 'image name' in k8s documentation
   # and 'image repository' in docker's guides.
-  image: ghcr.io/opentdf/attributes
+  repo: ghcr.io/opentdf/attributes
+  # Chart.AppVersion will be used for image tag, override here if needed
+  # tag: main
   # The container's `imagePullPolicy`
   pullPolicy: IfNotPresent
 

--- a/charts/claims/Chart.yaml
+++ b/charts/claims/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 maintainers:
   - name: Virtru
 icon: https://avatars.githubusercontent.com/u/90051847?s=200&v=4
-appVersion: "0.1.0"
+appVersion: "main"

--- a/charts/claims/templates/deployment.yaml
+++ b/charts/claims/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.image }}"
+          image: {{ .Values.image.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             {{- with .Values.secretRef }}

--- a/charts/claims/values.yaml
+++ b/charts/claims/values.yaml
@@ -15,7 +15,9 @@ serverPublicName: "Claims"
 image:
   # The image selector, also called the 'image name' in k8s documentation
   # and 'image repository' in docker's guides.
-  image: ghcr.io/opentdf/claims
+  repo: ghcr.io/opentdf/claims
+  # Chart.AppVersion will be used for image tag, override here if needed
+  # tag: main
   # The container's `imagePullPolicy`
   pullPolicy: IfNotPresent
 

--- a/charts/entitlements/Chart.yaml
+++ b/charts/entitlements/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 maintainers:
   - name: Virtru
 icon: https://avatars.githubusercontent.com/u/90051847?s=200&v=4
-appVersion: "0.0.1"
+appVersion: "main"

--- a/charts/entitlements/templates/deployment.yaml
+++ b/charts/entitlements/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.image }}"
+          image: {{ .Values.image.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             {{- with .Values.secretRef }}

--- a/charts/entitlements/values.yaml
+++ b/charts/entitlements/values.yaml
@@ -28,7 +28,9 @@ oidc:
 image:
   # The image selector, also called the 'image name' in k8s documentation
   # and 'image repository' in docker's guides.
-  image: ghcr.io/opentdf/entitlements
+  repo: ghcr.io/opentdf/entitlements
+  # Chart.AppVersion will be used for image tag, override here if needed
+  # tag: main
   # The container's `imagePullPolicy`
   pullPolicy: IfNotPresent
 

--- a/charts/kas/Chart.yaml
+++ b/charts/kas/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 maintainers:
   - name: Virtru
 icon: https://avatars.githubusercontent.com/u/90051847?s=200&v=4
-appVersion: "0.6.3a0"
+appVersion: "main"

--- a/charts/kas/templates/deployment.yaml
+++ b/charts/kas/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.image }}"
+          image: {{ .Values.image.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             {{- with .Values.secretRef }}

--- a/charts/kas/values.yaml
+++ b/charts/kas/values.yaml
@@ -13,7 +13,9 @@ replicaCount: 1
 image:
   # The image selector, also called the 'image name' in k8s documentation
   # and 'image repository' in docker's guides.
-  image: ghcr.io/opentdf/kas
+  repo: ghcr.io/opentdf/kas
+  # Chart.AppVersion will be used for image tag, override here if needed
+  # tag: main
   # The container's `imagePullPolicy`
   pullPolicy: IfNotPresent
 

--- a/charts/keycloak_bootstrap/Chart.yaml
+++ b/charts/keycloak_bootstrap/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 maintainers:
   - name: Virtru
 icon: https://avatars.githubusercontent.com/u/90051847?s=200&v=4
-appVersion: "0.4.2"
+appVersion: "main"

--- a/charts/keycloak_bootstrap/Chart.yaml
+++ b/charts/keycloak_bootstrap/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keycloak-bootstrap
-version: 0.4.2
+version: 0.4.3
 description: Keycloak Bootstrap Configurator Job
 type: application
 maintainers:

--- a/charts/keycloak_bootstrap/templates/keycloak-bootstrap-job.yaml
+++ b/charts/keycloak_bootstrap/templates/keycloak-bootstrap-job.yaml
@@ -13,7 +13,7 @@ spec:
       containers:
         - name: {{ .Values.name }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          image: {{ .Values.image.image }}
+          image: {{ .Values.image.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           {{- if .Values.istioTerminationHack }}
           command: ["/bin/sh", "-c"]
           # The following hack does 2 things:

--- a/charts/keycloak_bootstrap/values.yaml
+++ b/charts/keycloak_bootstrap/values.yaml
@@ -3,7 +3,9 @@ replicaCount: 1
 job:
   backoffLimit: 10
 image:
-  image: ghcr.io/opentdf/keycloak-bootstrap
+  repo: ghcr.io/opentdf/keycloak-bootstrap
+  # Chart.AppVersion will be used for image tag, override here if needed
+  # tag: main
   pullPolicy: Always
   pullSecret: virtru-regcred
 externalUrl: http://localhost:65432

--- a/charts/storage/Chart.yaml
+++ b/charts/storage/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 maintainers:
   - name: Virtru
 icon: https://avatars.githubusercontent.com/u/90051847?s=200&v=4
-appVersion: "0.1.0"
+appVersion: "main"

--- a/charts/storage/templates/deployment.yaml
+++ b/charts/storage/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.image }}"
+          image: {{ .Values.image.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             {{- with .Values.secretRef }}

--- a/charts/storage/values.yaml
+++ b/charts/storage/values.yaml
@@ -10,7 +10,9 @@ replicaCount: 1
 image:
   # The image selector, also called the 'image name' in k8s documentation
   # and 'image repository' in docker's guides.
-  image: ghcr.io/opentdf/storage
+  repo: ghcr.io/opentdf/storage
+  # Chart.AppVersion will be used for image tag, override here if needed
+  # tag: main
   # The container's `imagePullPolicy`
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
### Proposed Changes

Right now, all charts are published with image tags set to `main` - which is a rolling tag.

This means that someone installing a specific chart doesn't know what exact image build they're getting - they will always get the last image built and pushed to the `main` tag, which could change out from under them even if they use the exact same chart.

This means charts aren't idempotent for downstream consumers, which is a problem. 

This fixes that by:

  - Making all charts default to `Chart.AppVersion` for container pull tags, if no specific image tag override set
  - Allowing explicit image tag overrides for each chart (useful for testing, but people shouldn't check in tag overrides, for now we will have to protect against this with PR reviewer eyeballs, automation is possible.) 
  - Modifying the Actions workflow to override the Chart's `AppVersion` at packaging time with the current Git shortsha (which the images are already tagged with)
  
This means a published and packaged chart is locked to the image SHA tag it was packaged and published with, so images and charts are in lockstep (as they should be, Charts are the top-level artifact we're publishing, not naked images)


Note that we also are overwriting Helm tag versions on every `main` build as well, and as long as we are doing that we _still_ aren't idempotent for downstream consumers, so Part 2 of this fix requires that we tag the Helm charts with either a strictly incrementing Semver, or a Git SHA.

But at least this solves 1/2 of the problem.


### Checklist

- [x] I have added or updated unit tests and run them via `scripts/monotest all`
- [x] I have added or updated E2E cluster tests and run them via `kubectl kuttl test tests/cluster'
- [x] I have added or updated integration tests in `xtest` (if appropriate)
- [x] I have added or updated documentation / readme (if appropriate)
- [x] I have verified that my changes have not introduced new lint errors
- [x] I have updated the change log

### Testing Instructions
