### PR TITLE
Well I'm a doofus

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -177,7 +177,7 @@ jobs:
           for d in */ ; do
               if [ -f "$d/Chart.yaml" ]; then
                 echo "Rendering Helm chart $d to validate defaults..."
-                helm package $d --app-version ${GITHUB_SHA::7}
+                helm package $d --app-version sha-${GITHUB_SHA::7}
                 echo "Packaged Helm chart $d with appVersion (e.g. container tag) baked to ${GITHUB_SHA::7}"
                 echo *.tgz
                 helm push *.tgz oci://ghcr.io/${{ github.repository_owner }}/charts


### PR DESCRIPTION
### Proposed Changes

Docker images are stamped with `sha-<GITSHA>` - not `<GITSHA>`

Fix that.
### Checklist

- [x] I have added or updated unit tests and run them via `scripts/monotest all`
- [x] I have added or updated E2E cluster tests and run them via `kubectl kuttl test tests/cluster'
- [x] I have added or updated integration tests in `xtest` (if appropriate)
- [x] I have added or updated documentation / readme (if appropriate)
- [x] I have verified that my changes have not introduced new lint errors
- [x] I have updated the change log

### Testing Instructions
