### PR TITLE
Attempt to properly automate Helm chart versioning/publish

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -110,7 +110,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
-      - uses: yokawasa/action-setup-kube-tools@v0.7.1
+      - uses: yokawasa/action-setup-kube-tools@v0.8.0
         with:
           setup-tools: |
             kubectl
@@ -119,7 +119,6 @@ jobs:
           # This should be in sync with the minikube-deployed kube version below
           kubectl: "1.23.3"
           helm: "3.8.0"
-          helmv3: "3.8.0"
           tilt: "0.25.2"
       - run: |
           kustomize version

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -177,7 +177,7 @@ jobs:
           for d in */ ; do
               if [ -f "$d/Chart.yaml" ]; then
                 echo "Rendering Helm chart $d to validate defaults..."
-                helm package $d --app-version sha-${GITHUB_SHA::7}
+                helm package $d --app-version="sha-$(echo ${GITHUB_SHA} | cut -c1-7)"
                 echo "Packaged Helm chart $d with appVersion (e.g. container tag) baked to ${GITHUB_SHA::7}"
                 echo *.tgz
                 helm push *.tgz oci://ghcr.io/${{ github.repository_owner }}/charts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -154,6 +154,11 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     needs:
       - integration-test
+      # If we publish helm charts before we finish publishing the images
+      # they depend on, you can get into weirdness where the chart is pullable
+      # but the images are not, yet. Avoid that.
+      - build-and-publish-with-shared-base
+      - build-and-publish-isolated
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -174,11 +174,15 @@ jobs:
       - name: push
         run: |
           cd charts
+          short_ver=sha-${GITHUB_SHA::7}
+          escaped_version=$(printf '%s\n' "${short_ver}" | sed -e 's/[\/.]/\\./g')
           for d in */ ; do
               if [ -f "$d/Chart.yaml" ]; then
+                echo "Setting Chart.yaml version to ${short_ver}..."
+                sed -i "s/version\: 0\.0\.0/version\: $escaped_version/" $d/Chart.yaml
                 echo "Rendering Helm chart $d to validate defaults..."
-                helm package $d --app-version="sha-$(echo ${GITHUB_SHA} | cut -c1-7)"
-                echo "Packaged Helm chart $d with appVersion (e.g. container tag) baked to ${GITHUB_SHA::7}"
+                helm package $d --app-version="${short_ver}"
+                echo "Packaged Helm chart $d with chart version and appVersion (e.g. container tag) baked to ${GITHUB_SHA::7}"
                 echo *.tgz
                 helm push *.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
                 rm *.tgz

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -155,7 +155,7 @@ jobs:
     needs:
       - integration-test
       # If we publish helm charts before we finish publishing the images
-      # they depend on, you can get into weirdness where the chart is pullable
+      # they depend on, we can get into weirdness where the chart is pullable
       # but the images are not, yet. Avoid that.
       - build-and-publish-with-shared-base
       - build-and-publish-isolated
@@ -165,7 +165,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
-      - uses: yokawasa/action-setup-kube-tools@v0.7.1
+      - uses: yokawasa/action-setup-kube-tools@v0.8.0
         with:
           setup-tools: helm
           helm: "3.8.0"
@@ -177,17 +177,18 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       - name: push
+        #8char shortsha should be WAY more than enough, and this avoids a hard dep on in-image Git binaries: https://stackoverflow.com/a/18134919
         run: |
           cd charts
-          short_ver=sha-${GITHUB_SHA::7}
+          short_ver=sha-${GITHUB_SHA::8}
           escaped_version=$(printf '%s\n' "${short_ver}" | sed -e 's/[\/.]/\\./g')
           for d in */ ; do
               if [ -f "$d/Chart.yaml" ]; then
                 echo "Setting Chart.yaml version to ${short_ver}..."
-                sed -i "s/version\: 0\.0\.0/version\: $escaped_version/" $d/Chart.yaml
-                echo "Rendering Helm chart $d to validate defaults..."
+                sed -i "s/version\: .*/version\: $escaped_version/" $d/Chart.yaml
+                echo "Packaging Helm chart $d..."
                 helm package $d --app-version="${short_ver}"
-                echo "Packaged Helm chart $d with chart version and appVersion (e.g. container tag) baked to ${GITHUB_SHA::7}"
+                echo "Packaged Helm chart $d with chart version and appVersion (e.g. container tag) baked to ${short_ver}"
                 echo *.tgz
                 helm push *.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
                 rm *.tgz

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -177,7 +177,7 @@ jobs:
           for d in */ ; do
               if [ -f "$d/Chart.yaml" ]; then
                 echo "Rendering Helm chart $d to validate defaults..."
-                helm package $d --app-version ${GITHUB_SHA::7}
+                helm package $d --app-version sha-${GITHUB_SHA::7}
                 echo "Packaged Helm chart $d with appVersion (e.g. container tag) baked to ${GITHUB_SHA::7}"
                 echo *.tgz
                 helm push *.tgz oci://ghcr.io/${{ github.repository_owner }}/charts

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,4 @@
 name: Release Backend
-env:
-  KEYCLOAK_BASE_IMAGE: ghcr.io/opentdf/keycloak-multiarch-base
-  CONTAINER_ARCHS: linux/amd64,linux/arm64
 
 # Only run on release publish
 # GITHUB_SHA/REF will be set to the SHA/REF of the last commit in the tagged release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,59 @@
+name: Release Backend
+env:
+  KEYCLOAK_BASE_IMAGE: ghcr.io/opentdf/keycloak-multiarch-base
+  CONTAINER_ARCHS: linux/amd64,linux/arm64
+
+# Only run on release publish
+# GITHUB_SHA/REF will be set to the SHA/REF of the last commit in the tagged release
+on:
+  release:
+    types: [published]
+
+# This workflow is designed to be triggered only when someone publishes a Github release against a specific, preexisting Git tag in `main`
+# This workflow presumes that the normal `main` merge CI has already run for the particular merge SHA the release tag is bound to, as it should for every change to `main`
+# This workflow assumes the release tag is the literal Semver you want to use to stamp the release charts with.
+# This workflow will bake images into the (human-readable SEMVER from tag) charts using (generated from current tag SHA) tagged image builds, which presumably have already been built+pushed for this SHA
+jobs:
+  publish-helm-charts-release:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    timeout-minutes: 10
+    steps:
+      # Quick check to ensure the release we have is tagged with strict semver
+      # https://jubianchi.github.io/semver-check/#/
+      # e.g. no leading v.
+      - uses: rubenesp87/semver-validation-action@0.0.6
+        with:
+          version: ${{ github.event.release.tag_name }}
+      - uses: actions/checkout@v2
+      - uses: yokawasa/action-setup-kube-tools@v0.7.1
+        with:
+          setup-tools: helm
+          helm: "3.8.0"
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          logout: false
+      - name: push
+        run: |
+          cd charts
+          short_ver=sha-${GITHUB_SHA::7}
+          escaped_version=$(printf '%s\n' "${{ github.event.release.tag_name }}" | sed -e 's/[\/.]/\\./g')
+          for d in */ ; do
+              if [ -f "$d/Chart.yaml" ]; then
+                echo "Setting Chart.yaml version to ${{ github.event.release.tag_name }}..."
+                sed -i "s/version\: 0\.0\.0/version\: $escaped_version/" $d/Chart.yaml
+                echo "Rendering Helm chart $d to validate defaults..."
+                helm package $d --app-version="${short_ver}"
+                echo "Packaged Helm chart $d with chart version and appVersion (e.g. container tag) baked to ${GITHUB_SHA::7}"
+                echo *.tgz
+                helm push *.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
+                rm *.tgz
+              fi
+          done
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,5 @@
 name: Release Backend
 
-# Only run on release publish
 # GITHUB_SHA/REF will be set to the SHA/REF of the last commit in the tagged release
 on:
   release:
@@ -21,11 +20,12 @@ jobs:
       # Quick check to ensure the release we have is tagged with strict semver
       # https://jubianchi.github.io/semver-check/#/
       # e.g. no leading v.
+      # If this fails, you need to re-`git tag` your release commit with a valid semver tag
       - uses: rubenesp87/semver-validation-action@0.0.6
         with:
           version: ${{ github.event.release.tag_name }}
       - uses: actions/checkout@v2
-      - uses: yokawasa/action-setup-kube-tools@v0.7.1
+      - uses: yokawasa/action-setup-kube-tools@v0.8.0
         with:
           setup-tools: helm
           helm: "3.8.0"
@@ -37,17 +37,18 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       - name: push
+        #8char shortsha should be WAY more than enough, and this avoids a hard dep on in-image Git binaries: https://stackoverflow.com/a/18134919
         run: |
           cd charts
-          short_ver=sha-${GITHUB_SHA::7}
+          short_ver=sha-${GITHUB_SHA::8}
           escaped_version=$(printf '%s\n' "${{ github.event.release.tag_name }}" | sed -e 's/[\/.]/\\./g')
           for d in */ ; do
               if [ -f "$d/Chart.yaml" ]; then
                 echo "Setting Chart.yaml version to ${{ github.event.release.tag_name }}..."
-                sed -i "s/version\: 0\.0\.0/version\: $escaped_version/" $d/Chart.yaml
-                echo "Rendering Helm chart $d to validate defaults..."
+                sed -i "s/version\: .*/version\: $escaped_version/" $d/Chart.yaml
+                echo "Packaging Helm chart $d..."
                 helm package $d --app-version="${short_ver}"
-                echo "Packaged Helm chart $d with chart version and appVersion (e.g. container tag) baked to ${GITHUB_SHA::7}"
+                echo "Packaged Helm chart $d with chart version and appVersion (e.g. container tag) baked to ${short_ver}"
                 echo *.tgz
                 helm push *.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
                 rm *.tgz


### PR DESCRIPTION
This builds on https://github.com/opentdf/backend/pull/144

- On every push to `main` it updates each `Chart.yaml`'s version tag with `sha-<GITSHORTSHA>` - like image builds. This is treated as a prerelease Semver tag by Helm, so charts with `sha-XXX` will not be pulled by default, but can be explicitly fetched and used if desired.

- Added `release.yaml` - This is an Actions workflow that only runs when a Github Release is published. Github Releases have to be created from tags on `main`.
  - This release job assumes your release tag is the `semver` version you want your release to use - it pulls that and tags and (re)publishes Helm charts, with that release tag `semver`.
  
- Avoid publishing Helm charts until the images they consume are published -> was seeing some weirdness in `quickstart` builds where the chart was published and pulled but the image builds those charts needed were not done yet, so CI failed. It makes sense to wait for image builds before publishing charts anyway, so do that.
  
 So tl;dr 
 
 - every merge to `main` will produce SHA-tagged prerelease charts 
 - when a human explicitly tags a commit on `main` and publishes a Github Release from that tag, the `release.yaml` workflow will fire and publish new charts with the release version, as defined by the name of the tag. These will be the "release" artifacts.


### Checklist

- [x] I have added or updated unit tests and run them via `scripts/monotest all`
- [x] I have added or updated E2E cluster tests and run them via `kubectl kuttl test tests/cluster'
- [x] I have added or updated integration tests in `xtest` (if appropriate)
- [x] I have added or updated documentation / readme (if appropriate)
- [x] I have verified that my changes have not introduced new lint errors
- [x] I have updated the change log

### Testing Instructions
