### PR TITLE
Use valid semver for SHA builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -178,7 +178,7 @@ jobs:
       - name: push
         run: |
           cd charts
-          short_ver=sha-$(git rev-parse --short HEAD)
+          short_ver=0.0.0-sha-$(git rev-parse --short HEAD)
           escaped_version=$(printf '%s\n' "${short_ver}" | sed -e 's/[\/.]/\\./g')
           for d in */ ; do
               if [ -f "$d/Chart.yaml" ]; then


### PR DESCRIPTION
### Proposed Changes
For non-release builds that are SHA-based, we need the Helm version to be a valid Semver, or Helm complains.

So go with Semver prerelease format `0.0.0-sha-<SHA>`

### Checklist

- [x] I have added or updated unit tests and run them via `scripts/monotest all`
- [x] I have added or updated E2E cluster tests and run them via `kubectl kuttl test tests/cluster'
- [x] I have added or updated integration tests in `xtest` (if appropriate)
- [x] I have added or updated documentation / readme (if appropriate)
- [x] I have verified that my changes have not introduced new lint errors
- [x] I have updated the change log

### Testing Instructions
