### PR TITLE
🐛 Require bootstrap externalUrl param

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Render Templates
         run: |
           cd charts
-          for d in */ ; do
+          for d in * ; do
             if [[ $d == keycloak_bootstrap ]]; then
               echo "Rendering Helm chart to validate defaults..."
               helm template --set externalUrl=http://nowhere "$d"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,10 +44,17 @@ jobs:
         run: |
           cd charts
           for d in */ ; do
-              if [ -f "$d/Chart.yaml" ]; then
-                echo "Rendering Helm chart $d to validate defaults..."
-                helm template "$d"
+            if [[ $d == keycloak_bootstrap ]]; then
+              echo "Rendering Helm chart to validate defaults..."
+              helm template --set externalUrl=http://nowhere "$d"
+              if helm template "$d"; then
+                echo "$d should fail with defaults, as it has a required parameter"
+                exit 1
               fi
+            elif [ -f "$d/Chart.yaml" ]; then
+              echo "Rendering Helm chart $d to validate defaults..."
+              helm template "$d"
+            fi
           done
 
   scriptcheck:

--- a/Tiltfile
+++ b/Tiltfile
@@ -57,7 +57,7 @@ groups = {
 resources = []
 
 # isCI comes from tests/integration/Tiltfile
-#isCI = os.environ.get("ALPINE_VERSION", False) Why?
+# isCI = os.environ.get("ALPINE_VERSION", False) Why?
 isCI = False
 isPKItest = False
 
@@ -201,7 +201,9 @@ if "opentdf-abacus" in to_edit:
 if "opentdf-abacus-client-web" in to_edit:
     OPENTDF_ABACUS_YML = "tests/integration/frontend-local.yaml"
     # frontend folder should be next to backend
-    docker_build("opentdf/abacus", "../frontend", dockerfile = "../frontend/DockerfileTests")
+    docker_build(
+        "opentdf/abacus", "../frontend", dockerfile="../frontend/DockerfileTests"
+    )
 
 docker_build(
     CONTAINER_REGISTRY + "/opentdf/python-base",
@@ -496,9 +498,9 @@ k8s_resource(
 if isPKItest:
     k8s_resource("ingress-nginx-controller", port_forwards="4567:443")
     local_resource(
-    "pki-test",
-    "python3 tests/integration/pki-test/client_pki_test.py",
-    resource_deps=["keycloak-bootstrap", "keycloak", "opentdf-kas"]
+        "pki-test",
+        "python3 tests/integration/pki-test/client_pki_test.py",
+        resource_deps=["keycloak-bootstrap", "keycloak", "opentdf-kas"],
     )
 
 # The Postgres chart by default does not remove its Persistent Volume Claims: https://github.com/bitnami/charts/tree/master/bitnami/postgresql#uninstalling-the-chart

--- a/charts/keycloak_bootstrap/templates/keycloak-bootstrap-job.yaml
+++ b/charts/keycloak_bootstrap/templates/keycloak-bootstrap-job.yaml
@@ -36,7 +36,7 @@ spec:
             - name: ENABLE_PKI_BROWSER
               value: {{ .Values.pki.browserEnable | quote }}
             - name: OPENTDF_EXTERNAL_URL
-              value: {{ .Values.externalUrl }}
+              value: {{ required "Please define the abacus host URL for redirects" .Values.externalUrl }}
             - name: KEYCLOAK_INTERNAL_URL
               value: {{ .Values.keycloak.hostname }}
             - name: keycloak_admin_username

--- a/charts/keycloak_bootstrap/values.yaml
+++ b/charts/keycloak_bootstrap/values.yaml
@@ -7,7 +7,8 @@ image:
   # Chart.AppVersion will be used for image tag, override here if needed
   # tag: main
   pullPolicy: Always
-  pullSecret: virtru-regcred
+  # Used for imagePullSecret, if set
+  pullSecret:
 # URL of the abacus service. Used for redirect URIs, among others
 externalUrl:
 pki:

--- a/charts/keycloak_bootstrap/values.yaml
+++ b/charts/keycloak_bootstrap/values.yaml
@@ -8,7 +8,8 @@ image:
   # tag: main
   pullPolicy: Always
   pullSecret: virtru-regcred
-externalUrl: http://localhost:65432
+# URL of the abacus service. Used for redirect URIs, among others
+externalUrl:
 pki:
   directGrantEnable: "true"
   browserEnable: "true"

--- a/containers/keycloak-bootstrap/keycloak_bootstrap.py
+++ b/containers/keycloak-bootstrap/keycloak_bootstrap.py
@@ -381,7 +381,7 @@ def createTestClientForDCRAuth(keycloak_admin):
             "standardFlowEnabled": "true",
             "clientAuthenticatorType": "client-secret",
             "serviceAccountsEnabled": "true",
-            "baseUrl": f"{kc_internal_url}",
+            "baseUrl": f"{otdf_frontend_url}",
             "protocol": "openid-connect",
             "redirectUris": [f"{otdf_frontend_url}/*"],
             "webOrigins": ["+"],

--- a/tests/integration/backend-keycloak-bootstrap-values.yaml
+++ b/tests/integration/backend-keycloak-bootstrap-values.yaml
@@ -46,5 +46,7 @@ entitlements:
       - https://example.com/attr/Classification/value/S
       - https://example.com/attr/COI/value/PRX
 
+externalUrl: http://localhost:65432
+
 job:
   backoffLimit: 6


### PR DESCRIPTION
changes: _rev_

### Proposed Changes
_Please use the Jira Key or NOREF followd by the changes_

- This is used for the redirect-uri for the generated users
- as such, it must be set when we initialize the users, or they won't be able to log in to abacus
- Really, this should probably be a list? So we can have both abacus and other services running on different domains or maybe be more explicit about specific redirect paths


### Checklist

- [x] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `kubectl kuttl test tests/cluster'
- [ ] I have added or updated integration tests in `xtest` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [x] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
