### PR TITLE
🐛 PLAT-1474 Better bootstrap offline defaults

### DIFF
--- a/charts/kas/templates/deployment.yaml
+++ b/charts/kas/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      restartPolicy: IfNotPresent
+      restartPolicy: Never
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/kas/templates/deployment.yaml
+++ b/charts/kas/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      restartPolicy: Always
+      restartPolicy: IfNotPresent
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/kas/templates/deployment.yaml
+++ b/charts/kas/templates/deployment.yaml
@@ -60,7 +60,6 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      restartPolicy: Never
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/keycloak_bootstrap/values.yaml
+++ b/charts/keycloak_bootstrap/values.yaml
@@ -6,7 +6,8 @@ image:
   repo: ghcr.io/opentdf/keycloak-bootstrap
   # Chart.AppVersion will be used for image tag, override here if needed
   # tag: main
-  pullPolicy: Always
+  # Defaults to IfNotPresent to skip lookup of newer versions.
+  pullPolicy: IfNotPresent
   # Used for imagePullSecret, if set
   pullSecret:
 # URL of the abacus service. Used for redirect URIs, among others


### PR DESCRIPTION

changes: _rev_

### Proposed Changes
_Please use the Jira Key or NOREF followd by the changes_

- PLAT-1474
  - Updates the default pull policies to uniformly be IfNotPresent, which skips the 'out of date' check which always fails in air-gapped installs
  - This was already the default in most charts

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `kubectl kuttl test tests/cluster'
- [ ] I have added or updated integration tests in `xtest` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
