### PR TITLE
local build uses useStaticPolicy for entitlement-pdp

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -329,6 +329,7 @@ opentdf_entitlement_pdp_values = ""
 opentdf_entitlement_pdp_set = [
     "image.name=" + CONTAINER_REGISTRY + "/opentdf/entitlement-pdp",
     "createPolicySecret=false",
+    "opaConfig.policy.useStaticPolicy=true",
 ]
 
 opentdf_entitlement_store_values = ""


### PR DESCRIPTION
changes: _rev_

### Proposed Changes
uses a local static policy so one is not fetch remotely.  this enables the `tilt up` command to fully build all artifacts locally.

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt ci integration-test`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
