### PR TITLE
Fix OpenAPI path hint for `entitlement-pdp`

### DIFF
--- a/containers/entitlement-pdp/docs/docs.go
+++ b/containers/entitlement-pdp/docs/docs.go
@@ -155,7 +155,7 @@ const docTemplate = `{
 var SwaggerInfo = &swag.Spec{
 	Version:          "0.0.1",
 	Host:             "",
-	BasePath:         "/v1",
+	BasePath:         "",
 	Schemes:          []string{},
 	Title:            "entitlement-pdp",
 	Description:      "An implementation of a Policy Decision Point",

--- a/containers/entitlement-pdp/docs/swagger.json
+++ b/containers/entitlement-pdp/docs/swagger.json
@@ -13,7 +13,6 @@
         },
         "version": "0.0.1"
     },
-    "basePath": "/v1",
     "paths": {
         "/entitlements": {
             "post": {

--- a/containers/entitlement-pdp/docs/swagger.yaml
+++ b/containers/entitlement-pdp/docs/swagger.yaml
@@ -1,4 +1,3 @@
-basePath: /v1
 definitions:
   handlers.EntitlementsRequest:
     description: Request containing entity identifiers seeking entitlement. At least

--- a/containers/entitlement-pdp/main.go
+++ b/containers/entitlement-pdp/main.go
@@ -40,8 +40,6 @@ type EnvConfig struct {
 
 // @license.name BSD 3-Clause
 // @license.url https://opensource.org/licenses/BSD-3-Clause
-
-// @BasePath /v1
 func main() {
 	var zapLog *zap.Logger
 	var logErr error


### PR DESCRIPTION
Remove OAPI hint saying routes are hosted under a basePath of `/v1` - they are not.

### Checklist

- [x] I have added or updated unit tests and run them via `scripts/monotest all`
- [x] I have added or updated E2E cluster tests and run them via `tilt ci integration-test`
- [x] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
