### PR TITLE
PLAT-1822 REST API: Attribute can’t be created with Name which is already used for another authority.

### DIFF
--- a/containers/migration/schema.sql
+++ b/containers/migration/schema.sql
@@ -23,7 +23,7 @@ CREATE TABLE IF NOT EXISTS tdf_attribute.attribute
     namespace_id INTEGER NOT NULL REFERENCES tdf_attribute.attribute_namespace,
     state        VARCHAR NOT NULL,
     rule         VARCHAR NOT NULL,
-    name         VARCHAR NOT NULL UNIQUE, -- ??? COLLATE NOCASE
+    name         VARCHAR NOT NULL, -- ??? COLLATE NOCASE
     description  VARCHAR,
     values_array       TEXT[],
     group_by_attr     INTEGER REFERENCES tdf_attribute.attribute(id),

--- a/tests/integration/backend-postgresql-values.yaml
+++ b/tests/integration/backend-postgresql-values.yaml
@@ -39,7 +39,7 @@ initdbScripts:
         namespace_id INTEGER NOT NULL REFERENCES tdf_attribute.attribute_namespace,
         state        VARCHAR NOT NULL,
         rule         VARCHAR NOT NULL,
-        name         VARCHAR NOT NULL UNIQUE, -- ??? COLLATE NOCASE
+        name         VARCHAR NOT NULL, -- ??? COLLATE NOCASE
         description  VARCHAR,
         values_array TEXT[],
         group_by_attr INTEGER REFERENCES tdf_attribute.attribute(id),


### PR DESCRIPTION
PLAT-1822 REST API: Attribute can’t be created with Name which is already used for another authority.

changes: _rev_

### Proposed Changes
_Please use the Jira Key or NOREF followd by the changes_

- Issue #5432
  - Some change
  - Another change

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt ci integration-test`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
