### PR TITLE
Add insecure push target

### DIFF
--- a/containers/entitlement-pdp/entitlement-policy/Makefile
+++ b/containers/entitlement-pdp/entitlement-policy/Makefile
@@ -18,6 +18,11 @@ policypush: policybuild
 	@echo "Pushing '$(BUNDLETAG):$(POLICYVERSION)' OCI policy bundle to registry"
 	@policy push $(BUNDLETAG):$(POLICYVERSION)
 
+.PHONY: policypushinsecure
+policypushinsecure: policybuild
+	@echo "Pushing (without TLS verification, this is insecure and not recommended) '$(BUNDLETAG):$(POLICYVERSION)' OCI policy bundle to registry"
+	@policy push --insecure $(BUNDLETAG):$(POLICYVERSION)
+
 .PHONY: test
 test: localprep
 	@echo "Running all OPA tests"


### PR DESCRIPTION
### Proposed Changes
NOREF: This change adds a make target `policypushinsecure`.  It is not encouraged, but could be used with an insecure store.

