### PR TITLE
Try this to see if we can get more hints about the 403/confirm it's GHCR

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -213,7 +213,7 @@ jobs:
                 echo "Packaging Helm chart $d..."
                 helm package $d
                 echo "Packaged as" *.tgz
-                helm push *.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
+                helm push --debug *.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
                 rm *.tgz
               fi
           done
@@ -223,7 +223,7 @@ jobs:
           helm dependency update backend
           helm package backend
           echo "Packaged Helm chart [backend] as " *.tgz
-          helm push *.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
+          helm push --debug *.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
           rm *.tgz 
   build-base:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
### Proposed Changes

Chart pushes on `main` are failing with a 403 for just the `backend` chart (which is new): https://github.com/opentdf/backend/runs/7777262519?check_suite_focus=true#step:6:124

I've successfully manually pushed the backend chart from my laptop here: https://github.com/opentdf/backend/pkgs/container/backend%2Fcharts%2Fbackend/34482104?tag=0.0.1

And the other charts immediately before it publish just fine.

So not sure why Actions is barfing on this one. Pretty sure it's a Github authorization issue, somewhere. Add a `--debug` flag to `helm push` to see if we get more hints from that.

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
