### PR TITLE
⏪ Don't make subcharts require globals

### DIFF
--- a/README-keycloak-idp.md
+++ b/README-keycloak-idp.md
@@ -65,7 +65,7 @@ cli/bin/opentdf.mjs encrypt \
   --kasEndpoint http://localhost:65432/kas \
   --oidcEndpoint http://localhost:65432/keycloak \
   --auth tdf:tdf-client:123-456 \
-  --attributes http://opentdf-kas/attr/default/value/default \
+  --attributes http://kas/attr/default/value/default \
   --output sample.tdf \
   plaintext.txt
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ helm repo remove keycloak
 - Install [helm](https://helm.sh/)
     - On macOS via Homebrew: `brew install helm`
     - Others see https://helm.sh/docs/intro/install/
-    
+
 - Officially tagged and released container images and Helm charts are stored in Github's ghcr.io OCI image repository.
   - [You must follow github's instructions to log into that repository, and your cluster must have a valid pull secret for this registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry).
   - You must override the [`backend` chart's](./charts/backend) `global.opentdf.common.imagePullSecrets` property and supply it with the name of your cluster's existing/valid pull secret.

--- a/charts/attributes/templates/_helpers.tpl
+++ b/charts/attributes/templates/_helpers.tpl
@@ -65,10 +65,12 @@ Create the name of the service account to use
 Create OIDC Internal Url from a common value 
 */}}
 {{- define "attributes.oidc.internalUrl" }}
-{{- if .Values.global.opentdf.common.oidcUrlPath }}
+{{- if .Values.oidc.internalHost }}
+{{- .Values.oidc.internalHost }}
+{{- else if .Values.global.opentdf.common.oidcUrlPath }}
 {{- printf "%s/%s" .Values.global.opentdf.common.oidcInternalBaseUrl .Values.global.opentdf.common.oidcUrlPath }}
 {{- else }}
-{{- default .Values.global.opentdf.common.oidcInternalBaseUrl }}
+{{- .Values.global.opentdf.common.oidcInternalBaseUrl }}
 {{- end }}
 {{- end }}
 
@@ -77,9 +79,11 @@ Create OIDC Internal Url from a common value
 Create OIDC External Url from a common value  
 */}}
 {{- define "attributes.oidc.externalUrl" }}
-{{- if .Values.global.opentdf.common.oidcUrlPath }}
+{{- if .Values.oidc.externalHost }}
+{{- .Values.oidc.externalHost }}
+{{- else if .Values.global.opentdf.common.oidcUrlPath }}
 {{- printf "%s/%s" .Values.global.opentdf.common.oidcExternalBaseUrl .Values.global.opentdf.common.oidcUrlPath }}
 {{- else }}
-{{- default .Values.global.opentdf.common.oidcExternalBaseUrl }}
+{{- .Values.global.opentdf.common.oidcExternalBaseUrl }}
 {{- end }}
 {{- end }}

--- a/charts/attributes/templates/configmap.yaml
+++ b/charts/attributes/templates/configmap.yaml
@@ -13,8 +13,8 @@ data:
   OIDC_TOKEN_URL: {{ ( include "attributes.oidc.externalUrl" . ) }}/realms/{{ .Values.oidc.realm}}/protocol/openid-connect/token
   OIDC_SCOPES: {{ .Values.oidc.scopes | quote  }}
   OPENAPI_URL: {{ .Values.openapiUrl | quote }}
-  POSTGRES_DATABASE: {{ .Values.global.opentdf.common.postgres.database | quote  }}
-  POSTGRES_HOST: {{ .Values.global.opentdf.common.postgres.host | quote  }}
+  POSTGRES_DATABASE: {{ coalesce .Values.postgres.database .Values.global.opentdf.common.postgres.database | quote  }}
+  POSTGRES_HOST: {{ coalesce .Values.postgres.host .Values.global.opentdf.common.postgres.host | quote  }}
   POSTGRES_SCHEMA: {{ .Values.postgres.schema | quote  }}
   POSTGRES_USER: {{ .Values.postgres.user | quote  }}
   SERVER_LOG_LEVEL: {{ .Values.logLevel | quote }}

--- a/charts/attributes/templates/configmap.yaml
+++ b/charts/attributes/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "attributes.name" . }}-cm
+  name: {{ include "attributes.fullname" . }}-cm
 data:
   # TODO /auth and /token are well-known and can be hardcoded
   # we do not need two config properties for this - just one.

--- a/charts/attributes/templates/deployment.yaml
+++ b/charts/attributes/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
                 {{- toYaml . | nindent 16 }}
             {{- end }}
             - configMapRef:
-                name: {{ include "attributes.name" . }}-cm
+                name: {{ include "attributes.fullname" . }}-cm
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/attributes/templates/deployment.yaml
+++ b/charts/attributes/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           envFrom:
             {{- with .Values.secretRef }}
             - secretRef:
-              {{- tpl . $ | nindent 14 }}
+                {{- tpl . $ | nindent 16 }}
             {{- end }}
             - configMapRef:
               name: {{ include "attributes.fullname" . }}-cm

--- a/charts/attributes/templates/deployment.yaml
+++ b/charts/attributes/templates/deployment.yaml
@@ -36,10 +36,10 @@ spec:
           envFrom:
             {{- with .Values.secretRef }}
             - secretRef:
-                {{- toYaml . | nindent 16 }}
+              {{- tpl . $ | nindent 14 }}
             {{- end }}
             - configMapRef:
-                name: {{ include "attributes.fullname" . }}-cm
+              name: {{ include "attributes.fullname" . }}-cm
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/attributes/templates/deployment.yaml
+++ b/charts/attributes/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       labels:
         {{- include "attributes.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.global.opentdf.common.imagePullSecrets }}
+      {{- with (coalesce .Values.imagePullSecrets .Values.global.opentdf.common.imagePullSecrets) }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/attributes/templates/deployment.yaml
+++ b/charts/attributes/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
                 {{- tpl . $ | nindent 16 }}
             {{- end }}
             - configMapRef:
-              name: {{ include "attributes.fullname" . }}-cm
+                name: {{ include "attributes.fullname" . }}-cm
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/attributes/values.yaml
+++ b/charts/attributes/values.yaml
@@ -42,9 +42,9 @@ openapiUrl: ""
 # in the form of an environment variable such as:
 # OIDC_CLIENT_SECRET: myclientsecret
 oidc:
-  # Override for global.opentdf.common.oidcInternalHost & url path
+  # Override for global.opentdf.common.oidcInternalBaseUrl & url path
   internalHost:
-  # Override for global.opentdf.common.oidcExternalHost & url path
+  # Override for global.opentdf.common.oidcExternalBaseUrl & url path
   externalHost:
   realm: tdf
   clientId: tdf-attributes

--- a/charts/attributes/values.yaml
+++ b/charts/attributes/values.yaml
@@ -9,7 +9,7 @@ global:
       imagePullSecrets: []
       postgres:
         # postgres server's k8s name or global DNS for external server
-        host: opentdf-postgresql
+        host: postgresql
         # postgres server port
         port: 5432
         # The database name within the given server
@@ -64,7 +64,7 @@ image:
 # Overrides global.opentdf.common.imagePullSecrets
 imagePullSecrets:
 
-# Select a specific name for the resource, instead of the default, opentdf-attributes
+# Select a specific name for the resource, instead of the default, attributes
 nameOverride: ""
 
 # The fully qualified appname override

--- a/charts/attributes/values.yaml
+++ b/charts/attributes/values.yaml
@@ -42,6 +42,10 @@ openapiUrl: ""
 # in the form of an environment variable such as:
 # OIDC_CLIENT_SECRET: myclientsecret
 oidc:
+  # Override for global.opentdf.common.oidcInternalHost & url path
+  internalHost:
+  # Override for global.opentdf.common.oidcExternalHost & url path
+  externalHost:
   realm: tdf
   clientId: tdf-attributes
   scopes: email
@@ -55,6 +59,10 @@ image:
   # tag: main
   # The container's `imagePullPolicy`
   pullPolicy: IfNotPresent
+
+# JSON passed to the deployment's template.spec.imagePullSecrets.
+# Overrides global.opentdf.common.imagePullSecrets
+imagePullSecrets:
 
 # Select a specific name for the resource, instead of the default, opentdf-attributes
 nameOverride: ""
@@ -134,3 +142,9 @@ postgres:
   user: tdf_attribute_manager
   # The entitlement schema
   schema: tdf_attribute
+  # Override for global.opentdf.common.postgres.host
+  host:
+  # Override for global.opentdf.common.postgres.post
+  port:
+  # Override for global.opentdf.common.postgres.database
+  database:

--- a/charts/attributes/values.yaml
+++ b/charts/attributes/values.yaml
@@ -92,8 +92,8 @@ securityContext: {}
 # JSON to locate a k8s secret containing environment variables.
 # Notably, this file should include the following environemnt variable definitions:
 #     POSTGRES_PASSWORD: Password corresponding to postgres.user below
-secretRef:
-  name: attributes-secrets
+secretRef: |-
+  name: "{{ template "attributes.fullname" . }}-secret"
 
 # Service configuation information.
 service:

--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -32,6 +32,7 @@ dependencies:
     condition: embedded.postgresql
     tags: ["third-party"]
   - name: keycloakx
+    alias: keycloak
     repository: https://codecentric.github.io/helm-charts
     version: 1.4.2
     condition: embedded.keycloak

--- a/charts/backend/templates/_helpers.tpl
+++ b/charts/backend/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "backend.name" -}}
-{{- default .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/charts/backend/templates/postgres-initdb-secret.yaml
+++ b/charts/backend/templates/postgres-initdb-secret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: opentdf-postgresql-initdb-secret
   labels:
     app: {{ .Values.name }}
-    chart: {{ template "backend.chart" . }}
+    chart: {{ include "backend.chart" . | quote}}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}  
 type: Opaque    

--- a/charts/backend/templates/postgres-initdb-secret.yaml
+++ b/charts/backend/templates/postgres-initdb-secret.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: opentdf-postgresql-initdb-secret
+  name: {{ include "backend.fullname" . }}-initdb-secret
   labels:
-    app: {{ .Values.name }}
+    app: {{ .Chart.Name | quote }}
     chart: {{ include "backend.chart" . | quote}}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}  

--- a/charts/backend/templates/postgres-initdb-secret.yaml
+++ b/charts/backend/templates/postgres-initdb-secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "backend.fullname" . }}-initdb-secret
+  name: {{ include "postgresql.primary.fullname" .Subcharts.postgresql }}-initdb-secret
   labels:
     app: {{ .Chart.Name | quote }}
     chart: {{ include "backend.chart" . | quote}}

--- a/charts/backend/templates/secrets.yaml
+++ b/charts/backend/templates/secrets.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: opentdf-keycloak-secret
+  name: {{ template "keycloak.fullname" .Subcharts.keycloak }}-otdf-secret
   labels:
-    app: {{ .Values.Name }}
-    chart: {{ include "backend.chart" . | chart }}
+    app: {{ .Chart.Name | quote }}
+    chart: {{ include "backend.chart" . | quote }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}  
 type: Opaque
@@ -16,15 +16,15 @@ stringData:
   KC_DB_USERNAME: "keycloak_manager"
   KC_DB_PASSWORD: {{ .Values.secrets.postgres.dbPassword }}
   KC_DB_URL_HOST: {{ .Values.global.opentdf.common.postgres.host }}
-  KC_DB_URL_DATABASE: {{ .Values.keycloakx.externalDatabase.database }}
+  KC_DB_URL_DATABASE: {{ .Values.keycloak.externalDatabase.database }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: opentdf-postgres-secret
+  name:  {{ template "postgresql.primary.fullname" .Subcharts.postgresql }}-otdf-secret
   labels:
-    app: {{ .Values.name }}
-    chart: {{ include "backend.chart" . | chart }}
+    app: {{ .Chart.Name | quote }}
+    chart: {{ include "backend.chart" . | quote }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}    
 type: Opaque
@@ -34,10 +34,10 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: attributes-secrets
+  name: {{ template "attributes.fullname" . }}-otdf-secret
   labels:
-    app: {{ .Values.name }}
-    chart: {{ include "backend.chart" . | chart }}
+    app: {{ .Chart.Name | quote }}
+    chart: {{ include "backend.chart" . | quote }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}  
 type: Opaque
@@ -48,10 +48,10 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: keycloak-bootstrap-secrets
+  name: {{ template "keycloak-bootstrap.fullname" . }}-otdf-secret
   labels:
-    app: {{ .Values.name }}
-    chart: {{ include "backend.chart" . | chart }}
+    app: {{ .Chart.Name | quote }}
+    chart: {{ include "backend.chart" . | quote }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}  
 type: Opaque
@@ -65,10 +65,10 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: entitlement-store-secrets
+  name: {{ template "entitlement-store.fullname" . }}-otdf-secret
   labels:
-    app: {{ .Values.name }}
-    chart: {{ include "backend.chart" . | chart }}
+    app: {{ .Chart.Name | quote }}
+    chart: {{ include "backend.chart" . | quote }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}  
 type: Opaque
@@ -80,8 +80,8 @@ kind: Secret
 metadata:
   name: opentdf-entitlement-pdp-secret
   labels:
-    app: {{ .Values.name }}
-    chart: {{ include "backend.chart" . | chart }}
+    app: {{ .Chart.Name | quote }}
+    chart: {{ include "backend.chart" . | quote }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}  
 type: Opaque
@@ -91,10 +91,10 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: entitlements-secrets
+  name: {{ template "entitlements.fullname" . }}-otdf-secret
   labels:
-    app: {{ .Values.name }}
-    chart: {{ include "backend.chart" . | chart }}
+    app: {{ .Chart.Name | quote }}
+    chart: {{ include "backend.chart" . | quote }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}  
 type: Opaque

--- a/charts/backend/templates/secrets.yaml
+++ b/charts/backend/templates/secrets.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "keycloak.fullname" .Subcharts.keycloak }}-otdf-secret
+  name: {{ include "keycloak.fullname" .Subcharts.keycloak }}-otdf-secret
   labels:
     app: {{ .Chart.Name | quote }}
     chart: {{ include "backend.chart" . | quote }}
@@ -34,7 +34,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "attributes.fullname" . }}-otdf-secret
+  name: {{ include "attributes.fullname" .Subcharts.attributes }}-otdf-secret
   labels:
     app: {{ .Chart.Name | quote }}
     chart: {{ include "backend.chart" . | quote }}
@@ -48,7 +48,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "keycloak-bootstrap.fullname" . }}-otdf-secret
+  name: {{ index .Subcharts "keycloak-bootstrap" | include "keycloak-bootstrap.fullname" }}-otdf-secret
   labels:
     app: {{ .Chart.Name | quote }}
     chart: {{ include "backend.chart" . | quote }}
@@ -65,7 +65,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "entitlement-store.fullname" . }}-otdf-secret
+  name: {{ index .Subcharts "entitlement-store" | include "entitlement-store.fullname" }}-otdf-secret
   labels:
     app: {{ .Chart.Name | quote }}
     chart: {{ include "backend.chart" . | quote }}
@@ -78,7 +78,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: opentdf-entitlement-pdp-secret
+  name: {{ index .Subcharts "entitlement-pdp" | include "entitlement-pdp.fullname" }}-otdf-secret
   labels:
     app: {{ .Chart.Name | quote }}
     chart: {{ include "backend.chart" . | quote }}
@@ -91,7 +91,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "entitlements.fullname" . }}-otdf-secret
+  name: {{ index .Subcharts "entitlements" | include "entitlements.fullname" }}-otdf-secret
   labels:
     app: {{ .Chart.Name | quote }}
     chart: {{ include "backend.chart" . | quote }}

--- a/charts/backend/templates/secrets.yaml
+++ b/charts/backend/templates/secrets.yaml
@@ -3,8 +3,8 @@ kind: Secret
 metadata:
   name: opentdf-keycloak-secret
   labels:
-    app: {{ .Values.name }}
-    chart: {{ template "backend.chart" . }}
+    app: {{ .Values.Name }}
+    chart: {{ include "backend.chart" . | chart }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}  
 type: Opaque
@@ -24,7 +24,7 @@ metadata:
   name: opentdf-postgres-secret
   labels:
     app: {{ .Values.name }}
-    chart: {{ template "backend.chart" . }}
+    chart: {{ include "backend.chart" . | chart }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}    
 type: Opaque
@@ -37,7 +37,7 @@ metadata:
   name: attributes-secrets
   labels:
     app: {{ .Values.name }}
-    chart: {{ template "backend.chart" . }}
+    chart: {{ include "backend.chart" . | chart }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}  
 type: Opaque
@@ -51,7 +51,7 @@ metadata:
   name: keycloak-bootstrap-secrets
   labels:
     app: {{ .Values.name }}
-    chart: {{ template "backend.chart" . }}
+    chart: {{ include "backend.chart" . | chart }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}  
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: entitlement-store-secrets
   labels:
     app: {{ .Values.name }}
-    chart: {{ template "backend.chart" . }}
+    chart: {{ include "backend.chart" . | chart }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}  
 type: Opaque
@@ -81,7 +81,7 @@ metadata:
   name: opentdf-entitlement-pdp-secret
   labels:
     app: {{ .Values.name }}
-    chart: {{ template "backend.chart" . }}
+    chart: {{ include "backend.chart" . | chart }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}  
 type: Opaque
@@ -94,7 +94,7 @@ metadata:
   name: entitlements-secrets
   labels:
     app: {{ .Values.name }}
-    chart: {{ template "backend.chart" . }}
+    chart: {{ include "backend.chart" . | chart }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}  
 type: Opaque

--- a/charts/backend/templates/secrets.yaml
+++ b/charts/backend/templates/secrets.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ .Chart.Name | quote }}
     chart: {{ include "backend.chart" . | quote }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}  
+    heritage: {{ .Release.Service }}
 type: Opaque
 stringData:
   KEYCLOAK_ADMIN: {{ .Values.global.opentdf.common.keycloak.user }}
@@ -21,12 +21,12 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name:  {{ template "postgresql.primary.fullname" .Subcharts.postgresql }}-otdf-secret
+  name: {{ template "postgresql.primary.fullname" .Subcharts.postgresql }}-otdf-secret
   labels:
     app: {{ .Chart.Name | quote }}
     chart: {{ include "backend.chart" . | quote }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}    
+    heritage: {{ .Release.Service }}
 type: Opaque
 stringData:
   postgresql-password: {{ .Values.secrets.postgres.dbPassword }}
@@ -39,7 +39,7 @@ metadata:
     app: {{ .Chart.Name | quote }}
     chart: {{ include "backend.chart" . | quote }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}  
+    heritage: {{ .Release.Service }}
 type: Opaque
 stringData:
   POSTGRES_PASSWORD: {{ .Values.secrets.postgres.dbPassword }}
@@ -53,7 +53,7 @@ metadata:
     app: {{ .Chart.Name | quote }}
     chart: {{ include "backend.chart" . | quote }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}  
+    heritage: {{ .Release.Service }}
 type: Opaque
 stringData:
   CLIENT_SECRET: {{ .Values.secrets.keycloakBootstrap.clientSecret }}
@@ -70,7 +70,7 @@ metadata:
     app: {{ .Chart.Name | quote }}
     chart: {{ include "backend.chart" . | quote }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}  
+    heritage: {{ .Release.Service }}
 type: Opaque
 stringData:
   POSTGRES_PASSWORD: {{ .Values.secrets.postgres.dbPassword }}
@@ -83,7 +83,7 @@ metadata:
     app: {{ .Chart.Name | quote }}
     chart: {{ include "backend.chart" . | quote }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}  
+    heritage: {{ .Release.Service }}
 type: Opaque
 stringData:
   opaPolicyPullSecret: {{ .Values.secrets.opaPolicyPullSecret }}
@@ -96,7 +96,7 @@ metadata:
     app: {{ .Chart.Name | quote }}
     chart: {{ include "backend.chart" . | quote }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}  
+    heritage: {{ .Release.Service }}
 type: Opaque
 stringData:
   POSTGRES_PASSWORD: {{ .Values.secrets.postgres.dbPassword }}

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -1,4 +1,9 @@
-name: 'opentdf-backend'
+# Optionally override the fully qualified name
+fullnameOverride: ""
+
+# Optionally override the name
+nameOverride: ""
+
 
 embedded:
   keycloak: true

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -53,6 +53,8 @@ secrets:
 
 attributes:
   fullnameOverride: opentdf-attributes
+  secretRef: |-
+    name: "{{ template "attributes.fullname" . }}-otdf-secret"
 entitlement-pdp:
   opaConfig:
     policy:
@@ -62,6 +64,8 @@ entitlement-pdp:
       useStaticPolicy: true
   config:
     disableTracing: true
+  secretRef: |-
+    name: "{{ template "entitlement-pdp.fullname" . }}-otdf-secret"
 entitlement-store:
   fullnameOverride: opentdf-entitlement-store
 entitlements:
@@ -86,7 +90,7 @@ kas:
     verbose: "true"
     disableTracing: "true"
 
-keycloakx:
+keycloak:
   fullnameOverride: keycloak
   image:
     # Keycloak is a non-OpenTDF chart, but with an OpenTDF image
@@ -101,7 +105,7 @@ keycloakx:
     enabled: false
   externalDatabase:
     database: keycloak_database
-  extraEnv: |
+  extraEnv: |-
     - name: KC_LOG_LEVEL
       value: INFO
     - name: CLAIMS_URL
@@ -122,9 +126,9 @@ keycloakx:
       value: "edge"
     - name: JAVA_OPTS_APPEND
       value: -Djgroups.dns.query={{ include "keycloak.fullname" . }}-headless
-  extraEnvFrom: |
+  extraEnvFrom: |-
     - secretRef:
-        name: 'opentdf-keycloak-secret'
+        name: "{{ include "keycloak.fullname" . }}-otdf-secret"
   ingress:
     enabled: true
     ingressClassName: nginx
@@ -142,8 +146,8 @@ keycloakx:
     tls: []
 
 keycloak-bootstrap:
-  secretRef:
-    name: keycloak-bootstrap-secrets
+  secretRef: |-
+    name: "{{ template "keycloak-bootstrap.fullname" . }}-otdf-secret"
   keycloak:
     clientId: tdf-client
     realm: tdf
@@ -215,9 +219,11 @@ keycloak-bootstrap:
 
 postgresql:
   #  configuration https://github.com/bitnami/charts/tree/master/bitnami/postgresql/#parameters
-  fullnameOverride: opentdf-postgresql
+  fullnameOverride: postgresql
   image:
     debug: true
-  existingSecret: opentdf-postgres-secret
+  existingSecret: >
+    {{ template "postgresql.primary.fullname" . }}-otdf-secret
   initdbUser: postgres
-  initdbScriptsSecret: opentdf-postgresql-initdb-secret
+  initdbScriptsSecret: >
+    {{ include "backend.fullname" $ }}-initdb-secret

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -52,10 +52,11 @@ secrets:
 
 
 attributes:
-  fullnameOverride: opentdf-attributes
+  fullnameOverride: attributes
   secretRef: |-
     name: "{{ template "attributes.fullname" . }}-otdf-secret"
 entitlement-pdp:
+  fullnameOverride: entitlement-pdp
   opaConfig:
     policy:
       # `Tilt` tries make docker image caching automagic, but it isn't particularly
@@ -67,15 +68,16 @@ entitlement-pdp:
   secretRef: |-
     name: "{{ template "entitlement-pdp.fullname" . }}-otdf-secret"
 entitlement-store:
-  fullnameOverride: opentdf-entitlement-store
+  fullnameOverride: entitlement-store
 entitlements:
-  fullnameOverride: opentdf-entitlements
+  fullnameOverride: entitlements
 entity-resolution:
+  fullnameOverride: entity-resolution
   config:
     keycloak:
       legacy: true
 kas:
-  fullnameOverride: opentdf-kas
+  fullnameOverride: kas
   endpoints:
     easHost: http://opentdf-attributes:4020
     statsdHost: opentdf-statsd
@@ -146,6 +148,7 @@ keycloak:
     tls: []
 
 keycloak-bootstrap:
+  fullnameOverride: keycloak-bootstrap
   secretRef: |-
     name: "{{ template "keycloak-bootstrap.fullname" . }}-otdf-secret"
   keycloak:
@@ -223,7 +226,7 @@ postgresql:
   image:
     debug: true
   existingSecret: >
-    {{ template "postgresql.primary.fullname" . }}-otdf-secret
+    {{ include "postgresql.primary.fullname" . }}-otdf-secret
   initdbUser: postgres
   initdbScriptsSecret: >
-    {{ include "backend.fullname" $ }}-initdb-secret
+    {{ include "postgresql.primary.fullname" . }}-initdb-secret

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -138,6 +138,8 @@ keycloak:
   ingress:
     enabled: true
     ingressClassName: nginx
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: /auth/$2
     rules:
       - host: localhost
         paths: &paths

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -32,7 +32,7 @@ global:
         password: mykeycloakpassword
       postgres:
         # postgres server's k8s name or global DNS for external server
-        host: opentdf-postgresql
+        host: postgresql
         # postgres server port
         port: 5432
         # The database name within the given server
@@ -69,8 +69,12 @@ entitlement-pdp:
     name: "{{ template "entitlement-pdp.fullname" . }}-otdf-secret"
 entitlement-store:
   fullnameOverride: entitlement-store
+  secretRef: |-
+    name: "{{ template "entitlement-store.fullname" . }}-otdf-secret"
 entitlements:
   fullnameOverride: entitlements
+  secretRef: |-
+    name: "{{ template "entitlements.fullname" . }}-otdf-secret"
 entity-resolution:
   fullnameOverride: entity-resolution
   config:
@@ -79,7 +83,7 @@ entity-resolution:
 kas:
   fullnameOverride: kas
   endpoints:
-    easHost: http://opentdf-attributes:4020
+    attrHost: http://attributes:4020
     statsdHost: opentdf-statsd
   envConfig:
     attrAuthorityCert:
@@ -97,7 +101,7 @@ keycloak:
   image:
     # Keycloak is a non-OpenTDF chart, but with an OpenTDF image
     repository: ghcr.io/opentdf/keycloak
-    tag: head
+    tag: main
     pullPolicy: IfNotPresent
   command:
     - "/opt/keycloak/bin/kc.sh"
@@ -111,7 +115,7 @@ keycloak:
     - name: KC_LOG_LEVEL
       value: INFO
     - name: CLAIMS_URL
-      value: http://opentdf-entitlement-pdp:3355/entitlements
+      value: http://entitlement-pdp:3355/entitlements
     - name: KC_DB
       value: postgres
     - name: KC_DB_URL_PORT
@@ -156,7 +160,7 @@ keycloak-bootstrap:
     realm: tdf
 
   attributes:
-    hostname: http://opentdf-attributes:4020
+    hostname: http://attributes:4020
     realm: tdf
     clientId: dcr-test
     preloadedAuthorities:
@@ -184,7 +188,7 @@ keycloak-bootstrap:
       - PRF
 
   entitlements:
-    hostname: http://opentdf-entitlements:4030
+    hostname: http://entitlements:4020
     realms:
     - name: tdf
       clientId: dcr-test

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -84,7 +84,7 @@ kas:
   fullnameOverride: kas
   endpoints:
     attrHost: http://attributes:4020
-    statsdHost: opentdf-statsd
+    statsdHost: statsd
   envConfig:
     attrAuthorityCert:
     ecCert:
@@ -188,7 +188,7 @@ keycloak-bootstrap:
       - PRF
 
   entitlements:
-    hostname: http://entitlements:4020
+    hostname: http://entitlements:4030
     realms:
     - name: tdf
       clientId: dcr-test

--- a/charts/entitlement-pdp/templates/_helpers.tpl
+++ b/charts/entitlement-pdp/templates/_helpers.tpl
@@ -2,8 +2,8 @@
 Expand the name of the chart.
 */}}
 {{- define "entitlement-pdp.name" -}}
-{{- default .Chart.Name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Create a default fully qualified app name.
@@ -11,21 +11,21 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "entitlement-pdp.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "entitlement-pdp.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/charts/entitlement-pdp/templates/_helpers.tpl
+++ b/charts/entitlement-pdp/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "entitlementpdp.name" -}}
+{{- define "entitlement-pdp.name" -}}
 {{- default .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "entitlementpdp.fullname" -}}
+{{- define "entitlement-pdp.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -26,6 +26,6 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "entitlementpdp.chart" -}}
+{{- define "entitlement-pdp.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/charts/entitlement-pdp/templates/configmap.yaml
+++ b/charts/entitlement-pdp/templates/configmap.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.name }}-config
+  name: {{ include "entitlement-pdp.fullname" . }}-cm
   labels:
     app: {{ .Values.name }}
-    chart: {{ template "entitlementpdp.chart" . }}
+    chart: {{ include "entitlement-pdp.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:

--- a/charts/entitlement-pdp/templates/configmap.yaml
+++ b/charts/entitlement-pdp/templates/configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "entitlement-pdp.fullname" . }}-cm
   labels:
-    app: {{ .Values.name }}
+    app: {{ .Chart.Name | quote }}
     chart: {{ include "entitlement-pdp.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/charts/entitlement-pdp/templates/deployment.yaml
+++ b/charts/entitlement-pdp/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
         envFrom:
           {{- with .Values.secretRef }}
           - secretRef:
-            {{- tpl . $ | nindent 12 }}
+              {{- tpl . $ | nindent 14 }}
           {{- end }}
         ports:
           - containerPort: {{ .Values.config.listenPort }}

--- a/charts/entitlement-pdp/templates/deployment.yaml
+++ b/charts/entitlement-pdp/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- $cm := include "entitlement-pdp.fullname" | printf "%s-cm" -}}
+{{- $cm := include "entitlement-pdp.fullname" . | printf "%s-cm" -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -6,7 +6,7 @@ metadata:
   annotations:
     proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
   labels:
-    app: {{ .Values.name }}
+    app: {{ .Chart.Name | quote }}
     chart: {{ include "entitlement-pdp.chart" . | quote }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -14,18 +14,18 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ .Values.name }}
+      app: {{ .Chart.Name | quote }}
       release: {{ .Release.Name }}
   strategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-        app: {{ .Values.name }}
+        app: {{ .Chart.Name | quote }}
         release: {{ .Release.Name }}
     spec:
       containers:
-      - name: {{ .Values.name }}
+      - name: {{ include "entitlement-pdp.fullname" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         image: {{ .Values.image.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}
         env:
@@ -59,11 +59,18 @@ spec:
               configMapKeyRef:
                 name: {{ $cm }}
                 key: opaConfigPath
+          {{- if .Values.createPolicySecret }}
           - name: OPA_POLICYBUNDLE_PULLCRED
             valueFrom:
               secretKeyRef:
-                name: {{ include "entitlement-pdp.fullname" }}-secret
+                name: {{ include "entitlement-pdp.fullname" . }}-secret
                 key: opaPolicyPullSecret
+          {{- end }}
+        envFrom:
+          {{- with .Values.secretRef }}
+          - secretRef:
+            {{- tpl . $ | nindent 12 }}
+          {{- end }}
         ports:
           - containerPort: {{ .Values.config.listenPort }}
         volumeMounts:

--- a/charts/entitlement-pdp/templates/deployment.yaml
+++ b/charts/entitlement-pdp/templates/deployment.yaml
@@ -1,12 +1,13 @@
+{{- $cm := include "entitlement-pdp.fullname" | printf "%s-cm" -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.name }}
+  name: {{ include "entitlement-pdp.fullname" . }}
   annotations:
     proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
   labels:
     app: {{ .Values.name }}
-    chart: {{ template "entitlementpdp.chart" . }}
+    chart: {{ include "entitlement-pdp.chart" . | quote }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -31,37 +32,37 @@ spec:
           - name: LISTEN_PORT
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.name }}-config
+                name: {{ $cm }}
                 key: listenPort
           - name: EXTERNAL_HOST
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.name }}-config
+                name: {{ $cm }}
                 key: externalHost
           - name: VERBOSE
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.name }}-config
+                name: {{ $cm }}
                 key: verbose
           - name: DISABLE_TRACING
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.name }}-config
+                name: {{ $cm }}
                 key: disableTracing
           - name: OTLP_COLLECTOR_ENDPOINT
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.name }}-config
+                name: {{ $cm }}
                 key: otlpCollectorEndpoint
           - name: OPA_CONFIG_PATH
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.name }}-config
+                name: {{ $cm }}
                 key: opaConfigPath
           - name: OPA_POLICYBUNDLE_PULLCRED
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.name }}-secret
+                name: {{ include "entitlement-pdp.fullname" }}-secret
                 key: opaPolicyPullSecret
         ports:
           - containerPort: {{ .Values.config.listenPort }}
@@ -90,7 +91,7 @@ spec:
       volumes:
         - name: opa-config
           configMap:
-            name: {{ .Values.name }}-config
+            name: {{ $cm }}
             # An array of keys from the ConfigMap to create as files
             items:
             - key: "opa-config.yaml"

--- a/charts/entitlement-pdp/templates/entitlement-pdp-deployment.yaml
+++ b/charts/entitlement-pdp/templates/entitlement-pdp-deployment.yaml
@@ -95,7 +95,7 @@ spec:
             items:
             - key: "opa-config.yaml"
               path: "opa-config.yaml"
-      {{- with .Values.global.opentdf.common.imagePullSecrets }}
+      {{- with (coalesce .Values.imagePullSecrets .Values.global.opentdf.common.imagePullSecrets) }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/entitlement-pdp/templates/secret.yaml
+++ b/charts/entitlement-pdp/templates/secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: {{ include "entitlement-pdp.fullname" . }}-secret
   labels:
-    app: {{ .Values.name }}
+    app: {{ .Chart.Name | quote }}
     chart: {{ include "entitlement-pdp.chart" . | quote }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/charts/entitlement-pdp/templates/secret.yaml
+++ b/charts/entitlement-pdp/templates/secret.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.name }}-secret
+  name: {{ include "entitlement-pdp.fullname" . }}-secret
   labels:
     app: {{ .Values.name }}
-    chart: {{ template "entitlementpdp.chart" . }}
+    chart: {{ include "entitlement-pdp.chart" . | quote }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 type: Opaque

--- a/charts/entitlement-pdp/templates/service.yaml
+++ b/charts/entitlement-pdp/templates/service.yaml
@@ -9,8 +9,8 @@ metadata:
 spec:
   ports:
   - port: {{ .Values.config.listenPort }}
-    name: {{ .Values.name }}
+    name: {{ include "entitlement-pdp.fullname" . }}
     appProtocol: http
     targetPort: {{ .Values.config.listenPort }}
   selector:
-    app: {{ .Values.name }}
+    app: {{ .Chart.Name | quote }}

--- a/charts/entitlement-pdp/templates/service.yaml
+++ b/charts/entitlement-pdp/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.name }}
+  name: {{ include "entitlement-pdp.fullname" . }}
   labels:
     chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
     release: "{{ $.Release.Name }}"

--- a/charts/entitlement-pdp/values.yaml
+++ b/charts/entitlement-pdp/values.yaml
@@ -13,6 +13,10 @@ image:
   # tag: 0.0.5
   pullPolicy: IfNotPresent
 
+# JSON passed to the deployment's template.spec.imagePullSecrets.
+# Overrides global.opentdf.common.imagePullSecrets when set
+imagePullSecrets:
+
 secret:
   opaPolicyPullSecret: "YOUR_GHCR_PAT_HERE"
 

--- a/charts/entitlement-pdp/values.yaml
+++ b/charts/entitlement-pdp/values.yaml
@@ -1,4 +1,3 @@
-name: 'opentdf-entitlement-pdp'
 replicaCount: 3
 
 # Global values that may be overridden by a parent chart.
@@ -19,6 +18,9 @@ imagePullSecrets:
 
 secret:
   opaPolicyPullSecret: "YOUR_GHCR_PAT_HERE"
+
+# Additional secrets. You can also add opa
+secretRef:
 
 opaConfigMountPath: "/etc/opa/config"
 

--- a/charts/entitlement-store/templates/configmap.yaml
+++ b/charts/entitlement-store/templates/configmap.yaml
@@ -3,8 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ include "entitlement-store.name" . }}-cm
 data:
-  POSTGRES_DATABASE: {{ .Values.global.opentdf.common.postgres.database | quote }}
-  POSTGRES_HOST: {{ .Values.global.opentdf.common.postgres.host | quote }}
+  POSTGRES_DATABASE: {{ coalesce .Values.postgres.database .Values.global.opentdf.common.postgres.database | quote }}
+  POSTGRES_HOST: {{ coalesce .Values.postgres.host .Values.global.opentdf.common.postgres.host | quote }}
   POSTGRES_SCHEMA: {{ .Values.postgres.schema | quote }}
   POSTGRES_USER: {{ .Values.postgres.user | quote }}
   SERVER_LOG_LEVEL: {{ .Values.logLevel | quote }}

--- a/charts/entitlement-store/templates/deployment.yaml
+++ b/charts/entitlement-store/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
                 {{- tpl . $ | nindent 16 }}
             {{- end }}
             - configMapRef:
-              name: {{ include "entitlement-store.name" . }}-cm
+                name: {{ include "entitlement-store.name" . }}-cm
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/entitlement-store/templates/deployment.yaml
+++ b/charts/entitlement-store/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ include "entitlement-store.fullname" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ .Values.image.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}
@@ -36,10 +36,10 @@ spec:
           envFrom:
             {{- with .Values.secretRef }}
             - secretRef:
-                {{- toYaml . | nindent 16 }}
+              {{- tpl . $ | nindent 14 }}
             {{- end }}
             - configMapRef:
-                name: {{ include "entitlement-store.name" . }}-cm
+              name: {{ include "entitlement-store.name" . }}-cm
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/entitlement-store/templates/deployment.yaml
+++ b/charts/entitlement-store/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           envFrom:
             {{- with .Values.secretRef }}
             - secretRef:
-              {{- tpl . $ | nindent 14 }}
+                {{- tpl . $ | nindent 16 }}
             {{- end }}
             - configMapRef:
               name: {{ include "entitlement-store.name" . }}-cm

--- a/charts/entitlement-store/templates/deployment.yaml
+++ b/charts/entitlement-store/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       labels:
         {{- include "entitlement-store.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.global.opentdf.common.imagePullSecrets }}
+      {{- with (coalesce .Values.imagePullSecrets .Values.global.opentdf.common.imagePullSecrets) }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/entitlement-store/values.yaml
+++ b/charts/entitlement-store/values.yaml
@@ -27,9 +27,9 @@ serverPublicName: "entitlement-store"
 
 # Configure the container image to use in the deployment.
 image:
-  # Override for global.opentdf.common.oidcInternalHost & url path
+  # Override for global.opentdf.common.oidcInternalBaseUrl & url path
   internalHost:
-  # Override for global.opentdf.common.oidcExternalHost & url path
+  # Override for global.opentdf.common.oidcExternalBaseUrl & url path
   externalHost:
   # The image selector, also called the 'image name' in k8s documentation
   # and 'image repository' in docker's guides.

--- a/charts/entitlement-store/values.yaml
+++ b/charts/entitlement-store/values.yaml
@@ -73,8 +73,8 @@ securityContext: {}
 #     POSTGRES_PASSWORD: Password corresponding to postgres.user below
 #     KAS_CERTIFICATE: Public key for Key Access service
 #     KAS_EC_SECP256R1_CERTIFICATE: Public key (EC Mode) for Key Access service
-secretRef:
-  name: entitlement-store-secrets
+secretRef: |-
+  name: {{ template "entitlement-store.fullname" . }}-secret
 
 # Service configuation information.
 service:

--- a/charts/entitlement-store/values.yaml
+++ b/charts/entitlement-store/values.yaml
@@ -27,6 +27,10 @@ serverPublicName: "entitlement-store"
 
 # Configure the container image to use in the deployment.
 image:
+  # Override for global.opentdf.common.oidcInternalHost & url path
+  internalHost:
+  # Override for global.opentdf.common.oidcExternalHost & url path
+  externalHost:
   # The image selector, also called the 'image name' in k8s documentation
   # and 'image repository' in docker's guides.
   repo: ghcr.io/opentdf/entitlement_store
@@ -34,6 +38,10 @@ image:
   # tag: main
   # The container's `imagePullPolicy`
   pullPolicy: IfNotPresent
+
+# JSON passed to the deployment's template.spec.imagePullSecrets.
+# Overrides global.opentdf.common.imagePullSecrets
+imagePullSecrets:
 
 # Select a specific name for the resource, instead of the default, opentdf-entitlement-store
 nameOverride: ""
@@ -100,3 +108,9 @@ postgres:
   user: tdf_entitlement_reader
   # The entitlement schema
   schema: tdf_entitlement
+  # Override for global.opentdf.common.postgres.host
+  host:
+  # Override for global.opentdf.common.postgres.post
+  port:
+  # Override for global.opentdf.common.postgres.database
+  database:

--- a/charts/entitlement-store/values.yaml
+++ b/charts/entitlement-store/values.yaml
@@ -6,7 +6,7 @@ global:
       imagePullSecrets: []
       postgres:
         # postgres server's k8s name or global DNS for external server
-        host: opentdf-postgresql
+        host: postgresql
         # postgres server port
         port: 5432
         # The database name within the given server
@@ -43,7 +43,7 @@ image:
 # Overrides global.opentdf.common.imagePullSecrets
 imagePullSecrets:
 
-# Select a specific name for the resource, instead of the default, opentdf-entitlement-store
+# Select a specific name for the resource, instead of the default, entitlement-store
 nameOverride: ""
 
 # The fully qualified appname override

--- a/charts/entitlements/templates/_helpers.tpl
+++ b/charts/entitlements/templates/_helpers.tpl
@@ -67,10 +67,12 @@ Create the name of the service account to use
 Create OIDC Internal Url from a common value
 */}}
 {{- define "entitlements.oidc.internalUrl" }}
-{{- if .Values.global.opentdf.common.oidcUrlPath }}
+{{- if .Values.oidc.internalHost }}
+{{- .Values.oidc.internalHost }}
+{{- else if .Values.global.opentdf.common.oidcUrlPath }}
 {{- printf "%s/%s" .Values.global.opentdf.common.oidcInternalBaseUrl .Values.global.opentdf.common.oidcUrlPath }}
 {{- else }}
-{{- default .Values.global.opentdf.common.oidcInternalBaseUrl }}
+{{- .Values.global.opentdf.common.oidcInternalBaseUrl }}
 {{- end }}
 {{- end }}
 
@@ -79,9 +81,11 @@ Create OIDC Internal Url from a common value
 Create OIDC External Url from a common value  
 */}}
 {{- define "entitlements.oidc.externalUrl" }}
-{{- if .Values.global.opentdf.common.oidcUrlPath }}
+{{- if .Values.oidc.externalHost }}
+{{- .Values.oidc.externalHost }}
+{{- else if .Values.global.opentdf.common.oidcUrlPath }}
 {{- printf "%s/%s" .Values.global.opentdf.common.oidcExternalBaseUrl .Values.global.opentdf.common.oidcUrlPath }}
 {{- else }}
-{{- default .Values.global.opentdf.common.oidcExternalBaseUrl }}
+{{- .Values.global.opentdf.common.oidcExternalBaseUrl }}
 {{- end }}
 {{- end }}

--- a/charts/entitlements/templates/configmap.yaml
+++ b/charts/entitlements/templates/configmap.yaml
@@ -13,8 +13,8 @@ data:
   OIDC_TOKEN_URL: {{ ( include "entitlements.oidc.externalUrl" . ) }}/realms/{{ .Values.oidc.realm}}/protocol/openid-connect/token
   OIDC_SCOPES: {{ .Values.oidc.scopes | quote  }}
   OPENAPI_URL: {{ .Values.openapiUrl | quote }}
-  POSTGRES_DATABASE: {{ .Values.global.opentdf.common.postgres.database | quote }}
-  POSTGRES_HOST: {{ .Values.global.opentdf.common.postgres.host | quote }}
+  POSTGRES_DATABASE: {{ coalesce .Values.postgres.database .Values.global.opentdf.common.postgres.database | quote }}
+  POSTGRES_HOST: {{ coalesce .Values.postgres.host .Values.global.opentdf.common.postgres.host | quote }}
   POSTGRES_SCHEMA: {{ .Values.postgres.schema | quote }}
   POSTGRES_USER: {{ .Values.postgres.user | quote }}
   SERVER_LOG_LEVEL: {{ .Values.logLevel | quote }}

--- a/charts/entitlements/templates/deployment.yaml
+++ b/charts/entitlements/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       labels:
         {{- include "entitlements.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.global.opentdf.common.imagePullSecrets }}
+      {{- with (coalesce .Values.imagePullSecrets .Values.global.opentdf.common.imagePullSecrets) }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/entitlements/templates/deployment.yaml
+++ b/charts/entitlements/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ include "entitlements.fullname" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ .Values.image.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}
@@ -36,7 +36,7 @@ spec:
           envFrom:
             {{- with .Values.secretRef }}
             - secretRef:
-                {{- toYaml . | nindent 16 }}
+                {{- tpl . $ | nindent 16 }}
             {{- end }}
             - configMapRef:
                 name: {{ include "entitlements.name" . }}-cm

--- a/charts/entitlements/values.yaml
+++ b/charts/entitlements/values.yaml
@@ -42,9 +42,9 @@ openapiUrl: ""
 # in the form of an environment variable such as:
 # OIDC_CLIENT_SECRET: myclientsecret
 oidc:
-  # Override for global.opentdf.common.oidcInternalHost & url path
+  # Override for global.opentdf.common.oidcInternalBaseUrl & url path
   internalHost:
-  # Override for global.opentdf.common.oidcExternalHost & url path
+  # Override for global.opentdf.common.oidcExternalBaseUrl & url path
   externalHost:
   realm: tdf
   clientId: tdf-entitlement

--- a/charts/entitlements/values.yaml
+++ b/charts/entitlements/values.yaml
@@ -92,8 +92,8 @@ securityContext: {}
 # JSON to locate a k8s secret containing environment variables.
 # Notably, this file should include the following environemnt variable definitions:
 #     POSTGRES_PASSWORD: Password corresponding to postgres.user below
-secretRef:
-  name: entitlements-secrets
+secretRef: |-
+  name: {{ template "entitlements.fullname" . }}-secret
 
 # Service configuation information.
 service:

--- a/charts/entitlements/values.yaml
+++ b/charts/entitlements/values.yaml
@@ -9,7 +9,7 @@ global:
       imagePullSecrets: []
       postgres:
         # postgres server's k8s name or global DNS for external server
-        host: opentdf-postgresql
+        host: postgresql
         # postgres server port
         port: 5432
         # The database name within the given server
@@ -64,7 +64,7 @@ image:
 # Overrides global.opentdf.common.imagePullSecrets
 imagePullSecrets:
 
-# Select a specific name for the resource, instead of the default, opentdf-entitlements
+# Select a specific name for the resource, instead of the default, entitlements
 nameOverride: ""
 
 # The fully qualified appname override

--- a/charts/entitlements/values.yaml
+++ b/charts/entitlements/values.yaml
@@ -42,6 +42,10 @@ openapiUrl: ""
 # in the form of an environment variable such as:
 # OIDC_CLIENT_SECRET: myclientsecret
 oidc:
+  # Override for global.opentdf.common.oidcInternalHost & url path
+  internalHost:
+  # Override for global.opentdf.common.oidcExternalHost & url path
+  externalHost:
   realm: tdf
   clientId: tdf-entitlement
   scopes: email
@@ -55,6 +59,10 @@ image:
   # tag: main
   # The container's `imagePullPolicy`
   pullPolicy: IfNotPresent
+
+# JSON passed to the deployment's template.spec.imagePullSecrets.
+# Overrides global.opentdf.common.imagePullSecrets
+imagePullSecrets:
 
 # Select a specific name for the resource, instead of the default, opentdf-entitlements
 nameOverride: ""
@@ -134,3 +142,9 @@ postgres:
   user: tdf_entitlement_manager
   # The entitlement schema
   schema: tdf_entitlement
+  # Override for global.opentdf.common.postgres.host
+  host:
+  # Override for global.opentdf.common.postgres.post
+  port:
+  # Override for global.opentdf.common.postgres.database
+  database:

--- a/charts/entity-resolution/templates/_helpers.tpl
+++ b/charts/entity-resolution/templates/_helpers.tpl
@@ -34,5 +34,5 @@ Create chart name and version as used by the chart label.
 Create OIDC Internal Url from a common value   
 */}}
 {{- define "entityresolution.keycloakUrl" }}
-{{- default .Values.global.opentdf.common.oidcInternalBaseUrl }}
+{{- coalesce .Values.config.keycloak.url .Values.global.opentdf.common.oidcInternalBaseUrl }}
 {{- end }}

--- a/charts/entity-resolution/templates/_helpers.tpl
+++ b/charts/entity-resolution/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "entityresolution.name" -}}
+{{- define "entity-resolution.name" -}}
 {{- default .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "entityresolution.fullname" -}}
+{{- define "entity-resolution.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -26,13 +26,13 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "entityresolution.chart" -}}
+{{- define "entity-resolution.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create OIDC Internal Url from a common value   
 */}}
-{{- define "entityresolution.keycloakUrl" }}
+{{- define "entity-resolution.keycloakUrl" }}
 {{- coalesce .Values.config.keycloak.url .Values.global.opentdf.common.oidcInternalBaseUrl }}
 {{- end }}

--- a/charts/entity-resolution/templates/_helpers.tpl
+++ b/charts/entity-resolution/templates/_helpers.tpl
@@ -2,8 +2,8 @@
 Expand the name of the chart.
 */}}
 {{- define "entity-resolution.name" -}}
-{{- default .Chart.Name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Create a default fully qualified app name.
@@ -11,24 +11,24 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "entity-resolution.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "entity-resolution.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Create OIDC Internal Url from a common value   

--- a/charts/entity-resolution/templates/configmap.yaml
+++ b/charts/entity-resolution/templates/configmap.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.name }}-config
+  name: {{ include "entity-resolution.fullname" }}-cm
   labels:
     app: {{ .Values.name }}
-    chart: {{ template "entityresolution.chart" . }}
+    chart: {{ include "entity-resolution.chart" . | quote }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
@@ -13,7 +13,7 @@ data:
   verbose: {{ .Values.config.verbose | quote }}
   disableTracing: {{ .Values.config.disableTracing | quote }}
   otlpCollectorEndpoint: {{ .Values.config.otlpCollectorEndpoint | quote }}
-  keycloakUrl: {{ ( include "entityresolution.keycloakUrl" . ) | quote }}
+  keycloakUrl: {{ ( include "entity-resolution.keycloakUrl" . ) | quote }}
   keycloakRealm: {{ .Values.config.keycloak.realm | quote }}
   keycloakClientId: {{ .Values.config.keycloak.clientId | quote }}
   keycloakLegacy: {{ .Values.config.keycloak.legacy | quote }}

--- a/charts/entity-resolution/templates/configmap.yaml
+++ b/charts/entity-resolution/templates/configmap.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "entity-resolution.fullname" }}-cm
+  name: {{ include "entity-resolution.fullname" . }}-cm
   labels:
-    app: {{ .Values.name }}
+    app: {{ .Chart.Name | quote }}
     chart: {{ include "entity-resolution.chart" . | quote }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/charts/entity-resolution/templates/deployment.yaml
+++ b/charts/entity-resolution/templates/deployment.yaml
@@ -1,12 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.name }}
+  name: {{ include "entity-resolution.fullname" . }}
   annotations:
     proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
   labels:
     app: {{ .Values.name }}
-    chart: {{ template "entityresolution.chart" . }}
+    chart: {{ include "entity-resolution.chart" . | quote }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -31,52 +31,52 @@ spec:
           - name: LISTEN_PORT
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.name }}-config
+                name: {{ include "entity-resolution.fullname" . }}-cm
                 key: listenPort
           - name: EXTERNAL_HOST
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.name }}-config
+                name: {{ include "entity-resolution.fullname" . }}-cm
                 key: externalHost
           - name: VERBOSE
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.name }}-config
+                name: {{ include "entity-resolution.fullname" . }}-cm
                 key: verbose
           - name: DISABLE_TRACING
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.name }}-config
+                name: {{ include "entity-resolution.fullname" . }}-cm
                 key: disableTracing
           - name: OTLP_COLLECTOR_ENDPOINT
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.name }}-config
+                name: {{ include "entity-resolution.fullname" . }}-cm
                 key: otlpCollectorEndpoint
           - name: KEYCLOAK_URL
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.name }}-config
+                name: {{ include "entity-resolution.fullname" . }}-cm
                 key: keycloakUrl
           - name: KEYCLOAK_REALM
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.name }}-config
+                name: {{ include "entity-resolution.fullname" . }}-cm
                 key: keycloakRealm
           - name: KEYCLOAK_LEGACY
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.name }}-config
+                name: {{ include "entity-resolution.fullname" . }}-cm
                 key: keycloakLegacy
           - name: KEYCLOAK_CLIENT_ID
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.name }}-config
+                name: {{ include "entity-resolution.fullname" . }}-cm
                 key: keycloakClientId
           - name: KEYCLOAK_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.name }}-keycloak-client-secret
+                name: {{ include "entity-resolution.fullname" . }}-keycloak-client-secret
                 key: keycloakClientSecret
         ports:
           - containerPort: {{ .Values.config.listenPort }}

--- a/charts/entity-resolution/templates/deployment.yaml
+++ b/charts/entity-resolution/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
   labels:
-    app: {{ .Values.name }}
+    app: {{ .Chart.Name | quote }}
     chart: {{ include "entity-resolution.chart" . | quote }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -13,18 +13,18 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ .Values.name }}
+      app: {{ .Chart.Name | quote }}
       release: {{ .Release.Name }}
   strategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-        app: {{ .Values.name }}
+        app: {{ .Chart.Name | quote }}
         release: {{ .Release.Name }}
     spec:
       containers:
-      - name: {{ .Values.name }}
+      - name: {{ include "entity-resolution.fullname" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         image: {{ .Values.image.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}
         env:

--- a/charts/entity-resolution/templates/entity-resolution-deployment.yaml
+++ b/charts/entity-resolution/templates/entity-resolution-deployment.yaml
@@ -98,7 +98,7 @@ spec:
             port: {{ .Values.config.listenPort }}
           failureThreshold: 30
           periodSeconds: 10
-      {{- with .Values.global.opentdf.common.imagePullSecrets }}
+      {{- with (coalesce .Values.imagePullSecrets .Values.global.opentdf.common.imagePullSecrets) }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/entity-resolution/templates/secret.yaml
+++ b/charts/entity-resolution/templates/secret.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.name }}-keycloak-client-secret
+  name: {{ include "entity-resolution.fullname" . }}-keycloak-client-secret
   labels:
     app: {{ .Values.name }}
-    chart: {{ template "entityresolution.chart" . }}
+    chart: {{ include "entity-resolution.chart" . | quote }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 type: Opaque
@@ -17,7 +17,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.name }}-pull-secret
+  name: {{ include "entity-resolution.fullname" . }}-pull-secret
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ include "imagePullSecret" . }}

--- a/charts/entity-resolution/templates/secret.yaml
+++ b/charts/entity-resolution/templates/secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: {{ include "entity-resolution.fullname" . }}-keycloak-client-secret
   labels:
-    app: {{ .Values.name }}
+    app: {{ .Chart.Name | quote }}
     chart: {{ include "entity-resolution.chart" . | quote }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/charts/entity-resolution/templates/service.yaml
+++ b/charts/entity-resolution/templates/service.yaml
@@ -3,15 +3,15 @@ kind: Service
 metadata:
   name: {{ include "entity-resolution.fullname" . }}
   labels:
-    app: {{ .Values.name }}
+    app: {{ .Chart.Name | quote }}
     chart: {{ include "entity-resolution.chart" . | quote }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
   ports:
   - port: {{ .Values.config.listenPort }}
-    name: {{ .Values.name }}
+    name: include "entity-resolution.fullname"
     appProtocol: http
     targetPort: {{ .Values.config.listenPort }}
   selector:
-    app: {{ .Values.name }}
+    app: {{ .Chart.Name | quote }}

--- a/charts/entity-resolution/templates/service.yaml
+++ b/charts/entity-resolution/templates/service.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   ports:
   - port: {{ .Values.config.listenPort }}
-    name: include "entity-resolution.fullname"
+    name: {{ include "entity-resolution.fullname" . }}
     appProtocol: http
     targetPort: {{ .Values.config.listenPort }}
   selector:

--- a/charts/entity-resolution/templates/service.yaml
+++ b/charts/entity-resolution/templates/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.name }}
+  name: {{ include "entity-resolution.fullname" . }}
   labels:
     app: {{ .Values.name }}
-    chart: {{ template "entityresolution.chart" . }}
+    chart: {{ include "entity-resolution.chart" . | quote }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:

--- a/charts/entity-resolution/values.yaml
+++ b/charts/entity-resolution/values.yaml
@@ -30,7 +30,7 @@ config:
   disableTracing: "false"
   otlpCollectorEndpoint: "opentelemetry-collector.otel.svc:4317"
   keycloak:
-    # Override for global.opentdf.common.oidcInternalHost
+    # Override for global.opentdf.common.oidcInternalBaseUrl
     url:
     realm: "tdf"
     clientId: "tdf-entity-resolution-service"

--- a/charts/entity-resolution/values.yaml
+++ b/charts/entity-resolution/values.yaml
@@ -1,4 +1,8 @@
-name: 'opentdf-entity-resolution'
+# Optionally override the fully qualified name
+fullnameOverride: ""
+
+# Optionally override the name
+nameOverride: ""
 
 # Global values that may be overridden by a parent chart.
 global:

--- a/charts/entity-resolution/values.yaml
+++ b/charts/entity-resolution/values.yaml
@@ -14,6 +14,10 @@ image:
   # tag: 0.0.5 # Chart AppVersion will be used if this is not explicitly set.
   pullPolicy: IfNotPresent
 
+# JSON passed to the deployment's template.spec.imagePullSecrets.
+# Overrides global.opentdf.common.imagePullSecrets
+imagePullSecrets:
+
 createKeycloakClientSecret: true
 secret:
   keycloak:
@@ -26,6 +30,8 @@ config:
   disableTracing: "false"
   otlpCollectorEndpoint: "opentelemetry-collector.otel.svc:4317"
   keycloak:
+    # Override for global.opentdf.common.oidcInternalHost
+    url:
     realm: "tdf"
     clientId: "tdf-entity-resolution-service"
     # See https://github.com/Nerzal/gocloak/issues/346

--- a/charts/kas/templates/_helpers.tpl
+++ b/charts/kas/templates/_helpers.tpl
@@ -63,7 +63,7 @@ Create the name of the service account to use
 
 
 {{/*
-Create oidc endpoint from a common value    
+Create oidc endpoint from a common value
 */}}
 {{- define "kas.oidcPubkeyEndpoint" }}
 {{- coalesce .Values.endpoints.oidcPubkeyEndpoint .Values.global.opentdf.common.oidcInternalBaseUrl }}
@@ -71,36 +71,36 @@ Create oidc endpoint from a common value
 
 {{- define "kas.secretName" -}}
 {{- if .Values.externalSecretName }}
-{{- default .Values.externalSecretName }}
+{{- .Values.externalSecretName }}
 {{- else }}
 {{- printf "%s-secrets" ( include "kas.name" . ) }}
 {{- end }}
 {{- end }}
 
 {{- define "kas.secretFromString" -}}
-{{- if and (not .root.Values.externalEnvSecretName) (.value)  }}
-{{- default .value | b64enc }}
+{{- if and (not .root.Values.externalEnvSecretName) .value }}
+{{- b64enc .value }}
 {{- else }}
-{{- default "" }}
+{{- "" }}
 {{- end }}
-{{- end -}}
+{{- end }}
 
 {{- define "kas.ATTR_AUTHORITY_CERTIFICATE" }}
-{{- default ( include "kas.secretFromString" (dict "root" . "value" .Values.envConfig.attrAuthorityCert ) ) }}
+{{- dict "root" . "value" .Values.envConfig.attrAuthorityCert | include "kas.secretFromString" }}
 {{- end }}
 
 {{- define "kas.KAS_EC_SECP256R1_CERTIFICATE" }}
-{{- default ( include "kas.secretFromString" (dict "root" . "value" .Values.envConfig.ecCert ) ) }}
+{{- dict "root" . "value" .Values.envConfig.ecCert | include "kas.secretFromString" }}
 {{- end }}
 
 {{- define "kas.KAS_CERTIFICATE" }}
-{{- default ( include "kas.secretFromString" (dict "root" . "value" .Values.envConfig.cert ) ) }}
+{{- dict "root" . "value" .Values.envConfig.cert | include "kas.secretFromString" }}
 {{- end }}
 
 {{- define "kas.KAS_EC_SECP256R1_PRIVATE_KEY" }}
-{{- default ( include "kas.secretFromString" (dict "root" . "value" .Values.envConfig.ecPrivKey ) ) }}
+{{- dict "root" . "value" .Values.envConfig.ecPrivKey | include "kas.secretFromString" }}
 {{- end }}
 
 {{- define "kas.KAS_PRIVATE_KEY" }}
-{{- default ( include "kas.secretFromString" (dict "root" . "value" .Values.envConfig.privKey ) ) }}
+{{- dict "root" . "value" .Values.envConfig.privKey | include "kas.secretFromString" }}
 {{- end }}

--- a/charts/kas/templates/_helpers.tpl
+++ b/charts/kas/templates/_helpers.tpl
@@ -66,7 +66,7 @@ Create the name of the service account to use
 Create oidc endpoint from a common value    
 */}}
 {{- define "kas.oidcPubkeyEndpoint" }}
-{{- default .Values.global.opentdf.common.oidcInternalBaseUrl }}
+{{- coalesce .Values.endpoints.oidcPubkeyEndpoint .Values.global.opentdf.common.oidcInternalBaseUrl }}
 {{- end }}
 
 {{- define "kas.secretName" -}}

--- a/charts/kas/templates/_helpers.tpl
+++ b/charts/kas/templates/_helpers.tpl
@@ -66,7 +66,8 @@ Create the name of the service account to use
 Create oidc endpoint from a common value
 */}}
 {{- define "kas.oidcPubkeyEndpoint" }}
-{{- coalesce .Values.endpoints.oidcPubkeyEndpoint .Values.global.opentdf.common.oidcInternalBaseUrl }}
+{{- $t := coalesce .Values.endpoints.oidcPubkeyEndpoint .Values.global.opentdf.common.oidcInternalBaseUrl }}
+{{- tpl $t $ | nindent 16 }}
 {{- end }}
 
 {{- define "kas.secretName" -}}

--- a/charts/kas/templates/configmap.yaml
+++ b/charts/kas/templates/configmap.yaml
@@ -9,13 +9,17 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: kas
 data:
-  ATTR_AUTHORITY_HOST: {{ coalesce .Values.endpoints.attrHost .Values.endpoints.easHost | quote  }}
+  {{- with (coalesce .Values.endpoints.attrHost .Values.endpoints.easHost) }}
+  ATTR_AUTHORITY_HOST: {{ tpl . $ | quote  }}
+  {{- end }}
   FLASK_DEBUG: {{ .Values.flaskDebug | quote }}
   GUNICORN_WORKERS: {{ .Values.gunicornWorkers | default 1 | quote }}
   KEYCLOAK_HOST: {{ include "kas.oidcPubkeyEndpoint" . | quote }}
   LOGLEVEL: {{ .Values.logLevel | quote }}
   VERBOSE: {{ .Values.pdp.verbose | quote }}
-  STATSD_HOST: {{ .Values.endpoints.statsdHost | quote }}
+  {{- with .Values.endpoints.statsdHost }}
+  STATSD_HOST: {{ tpl . $ | quote  }}
+  {{- end }}
   DISABLE_TRACING: {{ .Values.pdp.disableTracing | quote }}
 
   USE_KEYCLOAK: "1"

--- a/charts/kas/templates/configmap.yaml
+++ b/charts/kas/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
   ATTR_AUTHORITY_HOST: {{ coalesce .Values.endpoints.attrHost .Values.endpoints.easHost | quote  }}
   FLASK_DEBUG: {{ .Values.flaskDebug | quote }}
   GUNICORN_WORKERS: {{ .Values.gunicornWorkers | default 1 | quote }}
-  KEYCLOAK_HOST: {{ ( include "kas.oidcPubkeyEndpoint" . ) | quote }}
+  KEYCLOAK_HOST: {{ include "kas.oidcPubkeyEndpoint" . | quote }}
   LOGLEVEL: {{ .Values.logLevel | quote }}
   VERBOSE: {{ .Values.pdp.verbose | quote }}
   STATSD_HOST: {{ .Values.endpoints.statsdHost | quote }}

--- a/charts/kas/templates/deployment.yaml
+++ b/charts/kas/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       labels:
         {{- include "kas.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.global.opentdf.common.imagePullSecrets }}
+      {{- with (coalesce .Values.imagePullSecrets .Values.global.opentdf.common.imagePullSecrets) }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kas/templates/deployment.yaml
+++ b/charts/kas/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ include "kas.secretName" . }} 
-            {{- if .Values.extraEnvSecretName }}    
+            {{- if .Values.extraEnvSecretName }}
             - secretRef:
                 name: {{ .Values.extraEnvSecretName }} 
             {{- end }}

--- a/charts/kas/values.yaml
+++ b/charts/kas/values.yaml
@@ -46,9 +46,6 @@ nameOverride: ""
 # The fully qualified appname override
 fullnameOverride: ""
 
-labels:
-  app: "kas"
-
 # A service account to create
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/kas/values.yaml
+++ b/charts/kas/values.yaml
@@ -2,7 +2,7 @@
 global:
   opentdf:
     common:
-      oidcInternalBaseUrl: http://localhost:65432
+      oidcInternalBaseUrl: http://keycloak-http
       # JSON passed to the deployment's template.spec.imagePullSecrets
       imagePullSecrets: []
 
@@ -35,6 +35,10 @@ image:
   # tag: main
   # The container's `imagePullPolicy`
   pullPolicy: IfNotPresent
+
+# JSON passed to the deployment's template.spec.imagePullSecrets.
+# Overrides global.opentdf.common.imagePullSecrets
+imagePullSecrets:
 
 # Select a specific name for the resource, instead of the default, opentdf-kas
 nameOverride: ""
@@ -132,8 +136,8 @@ maxUnavailable: 1
 endpoints:
   attrHost: http://opentdf-attributes:4020
   statsdHost: opentdf-statsd
-  # TODO replace this with a template var instead of a hardcode when Keycloak charts are merged into opentdf/backend.
-  oidcPubkeyEndpoint: http://opentdf-keycloak
+  # Local override for global.opentdf.common.oidcInternalBaseUrl + path
+  oidcPubkeyEndpoint:
 
 # Adds a container livenessProbe, if set.
 livenessProbe:

--- a/charts/kas/values.yaml
+++ b/charts/kas/values.yaml
@@ -40,7 +40,7 @@ image:
 # Overrides global.opentdf.common.imagePullSecrets
 imagePullSecrets:
 
-# Select a specific name for the resource, instead of the default, opentdf-kas
+# Select a specific name for the resource, instead of the default, kas
 nameOverride: ""
 
 # The fully qualified appname override
@@ -131,8 +131,8 @@ affinity: {}
 maxUnavailable: 1
 
 endpoints:
-  attrHost: http://opentdf-attributes:4020
-  statsdHost: opentdf-statsd
+  attrHost: http://attributes:4020
+  statsdHost: statsd
   # Local override for global.opentdf.common.oidcInternalBaseUrl + path
   oidcPubkeyEndpoint:
 

--- a/charts/keycloak-bootstrap/templates/_helpers.tpl
+++ b/charts/keycloak-bootstrap/templates/_helpers.tpl
@@ -8,7 +8,7 @@
 Expand the name of the chart.
 */}}
 {{- define "keycloak-bootstrap.name" -}}
-{{- default .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/charts/keycloak-bootstrap/templates/_helpers.tpl
+++ b/charts/keycloak-bootstrap/templates/_helpers.tpl
@@ -41,22 +41,13 @@ Create chart name and version as used by the chart label.
 Create OIDC Internal Url from a common value (if it exists)
 */}}
 {{- define "bootstrap.oidc.internalUrl" }}
+{{- if .Values.keycloak.hostname }}
+{{- .Values.keycloak.hostname }}
+{{- $host := .Values.global.opentdf.common.oidcInternalBaseUrl -}}
 {{- if .Values.global.opentdf.common.oidcUrlPath }}
-{{- printf "%s/%s" .Values.global.opentdf.common.oidcInternalBaseUrl .Values.global.opentdf.common.oidcUrlPath }}
+{{- printf "%s/%s" $host .Values.global.opentdf.common.oidcUrlPath }}
 {{- else }}
-{{- default .Values.global.opentdf.common.oidcInternalBaseUrl }}
-{{- end }}
-{{- end }}
-
-{{/*
-Create OIDC External Url from a common value (if it exists)
-*/}}
-{{- define "bootstrap.oidc.externalUrl" }}
-{{- $extHost := .Values.global.opentdf.common.oidcExternalBaseUrl }}
-{{- if .Values.global.opentdf.common.oidcUrlPath }}
-{{- printf "%s/%s" $extHost .Values.global.opentdf.common.oidcUrlPath }}
-{{- else }}
-{{- default $extHost }}
+{{- $host }}
 {{- end }}
 {{- end }}
 
@@ -64,13 +55,14 @@ Create OIDC External Url from a common value (if it exists)
 The base URL for clients by default
 */}}
 {{- define "bootstrap.opentdf.externalUrl" }}
-{{- .Values.opentdf.externalUrl | default .Values.global.opentdf.common.oidcExternalBaseUrl }}
+{{- coalesce .Values.opentdf.externalUrl .Values.externalUrl .Values.global.opentdf.common.oidcExternalBaseUrl
+  | required "Please define the abacus host URL for redirects" }}
 {{- end }}
 
 {{/*
 Valid redirect URIs
 */}}
 {{- define "bootstrap.opentdf.redirectUris" }}
-{{- $defHost := (.Values.opentdf.externalUrl | default .Values.global.opentdf.common.oidcExternalBaseUrl) }}
+{{- $defHost := coalesce .Values.opentdf.externalUrl .Values.externalUrl .Values.global.opentdf.common.oidcExternalBaseUrl }}
 {{- join " " .Values.opentdf.redirectUris | default (printf "%s/*" $defHost) }}
 {{- end }}

--- a/charts/keycloak-bootstrap/templates/_helpers.tpl
+++ b/charts/keycloak-bootstrap/templates/_helpers.tpl
@@ -43,11 +43,13 @@ Create OIDC Internal Url from a common value (if it exists)
 {{- define "bootstrap.oidc.internalUrl" }}
 {{- if .Values.keycloak.hostname }}
 {{- .Values.keycloak.hostname }}
+{{- else }}
 {{- $host := .Values.global.opentdf.common.oidcInternalBaseUrl -}}
 {{- if .Values.global.opentdf.common.oidcUrlPath }}
 {{- printf "%s/%s" $host .Values.global.opentdf.common.oidcUrlPath }}
 {{- else }}
 {{- $host }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/keycloak-bootstrap/templates/keycloak-bootstrap-job.yaml
+++ b/charts/keycloak-bootstrap/templates/keycloak-bootstrap-job.yaml
@@ -55,23 +55,23 @@ spec:
               value: {{ .Values.keycloak.passwordUsers }}
             {{- with .Values.keycloak.clientId }}
             - name: CLIENT_ID
-              value: {{ . | quote }}
+              value: {{ tpl . $ | quote }}
             {{- end }}
             {{- with .Values.attributes.hostname }}
             - name: ATTRIBUTE_AUTHORITY_HOST
-              value: {{ . | quote }}
+              value: {{ tpl . $ | quote }}
             {{- end }}
             {{- with .Values.entitlements.hostname }}
             - name: ENTITLEMENT_HOST
-              value: {{ . | quote }}
+              value: {{ tpl . $ | quote }}
             {{- end }}
             {{- with .Values.attributes.clientId }}
             - name: ATTRIBUTES_CLIENT_ID
-              value: {{ . | quote }}
+              value: {{ tpl . $ | quote }}
             {{- end }}
             {{- with .Values.attributes.realm }}
             - name: ATTRIBUTES_REALM
-              value: {{ . | quote }}
+              value: {{ tpl . $ | quote }}
             {{- end }}
           {{- with .Values.secretRef }}
           envFrom:

--- a/charts/keycloak-bootstrap/templates/keycloak-bootstrap-job.yaml
+++ b/charts/keycloak-bootstrap/templates/keycloak-bootstrap-job.yaml
@@ -46,32 +46,32 @@ spec:
             - name: ENABLE_PKI_BROWSER
               value: {{ .Values.pki.browserEnable | quote }}
             - name: OPENTDF_EXTERNAL_URL
-              value: {{ ( include "bootstrap.opentdf.externalUrl" . ) }}
+              value: {{ ( include "bootstrap.opentdf.externalUrl" . ) | quote }}
             - name: OPENTDF_REDIRECT_URIS
-              value: {{ ( include "bootstrap.opentdf.redirectUris" . ) }}
+              value: {{ ( include "bootstrap.opentdf.redirectUris" . ) | quote }}
             - name: KEYCLOAK_INTERNAL_URL
-              value: {{ ( include "bootstrap.oidc.internalUrl" . ) }}
+              value: {{ ( include "bootstrap.oidc.internalUrl" . ) | quote }}
             - name: passwordUsers
               value: {{ .Values.keycloak.passwordUsers }}
             {{- with .Values.keycloak.clientId }}
             - name: CLIENT_ID
-              value: {{ . }}
+              value: {{ . | quote }}
             {{- end }}
             {{- with .Values.attributes.hostname }}
             - name: ATTRIBUTE_AUTHORITY_HOST
-              value: {{ . }}
+              value: {{ . | quote }}
             {{- end }}
             {{- with .Values.entitlements.hostname }}
             - name: ENTITLEMENT_HOST
-              value: {{ . }}
+              value: {{ . | quote }}
             {{- end }}
             {{- with .Values.attributes.clientId }}
             - name: ATTRIBUTES_CLIENT_ID
-              value: {{ . }}
+              value: {{ . | quote }}
             {{- end }}
             {{- with .Values.attributes.realm }}
             - name: ATTRIBUTES_REALM
-              value: {{ . }}
+              value: {{ . | quote }}
             {{- end }}
           {{- with .Values.secretRef }}
           envFrom:
@@ -86,7 +86,7 @@ spec:
           configMap:
             name: {{ include "keycloak-bootstrap.fullname" . }}-cm
       restartPolicy: Never
-      {{- with .Values.global.opentdf.common.imagePullSecrets }}
+      {{- with (coalesce .Values.imagePullSecrets .Values.global.opentdf.common.imagePullSecrets) }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/keycloak-bootstrap/templates/keycloak-bootstrap-job.yaml
+++ b/charts/keycloak-bootstrap/templates/keycloak-bootstrap-job.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: {{ .Values.name }}
   labels:
-    app: {{ .Values.name }}
+    app: {{ .Chart.Name | quote }}
     chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
@@ -76,7 +76,7 @@ spec:
           {{- with .Values.secretRef }}
           envFrom:
             - secretRef:
-                {{- toYaml . | nindent 16 }}
+                {{- tpl . $ | nindent 16 }}
           {{- end }}
           volumeMounts:
             - name: keycloak-bootstrap-config-volume

--- a/charts/keycloak-bootstrap/templates/keycloak-bootstrap-job.yaml
+++ b/charts/keycloak-bootstrap/templates/keycloak-bootstrap-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Values.name }}
+  name: {{ include "keycloak-bootstrap.fullname" . }}
   labels:
     app: {{ .Chart.Name | quote }}
     chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
@@ -11,7 +11,7 @@ spec:
   template:
     spec:
       containers:
-        - name: {{ .Values.name }}
+        - name: {{ include "keycloak-bootstrap.fullname" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           image: {{ .Values.image.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           command: ["/bin/sh", "-c"]
@@ -32,7 +32,7 @@ spec:
             - |-
               {{- if .Values.istioTerminationHack }}
               trap "curl --max-time 2 -s -f -XPOST http://127.0.0.1:15000/quitquitquit" EXIT
-              while ! curl -s -f http://127.0.0.1:15020/healthz/ready; do sleep 1; done              
+              while ! curl -s -f http://127.0.0.1:15020/healthz/ready; do sleep 1; done
               {{- end }}
               echo "[INFO] Waiting for service [{{ ( include "bootstrap.oidc.internalUrl" . ) }}]"
               while ! curl -f {{ ( include "bootstrap.oidc.internalUrl" . ) }}/realms/master; do

--- a/charts/keycloak-bootstrap/values.yaml
+++ b/charts/keycloak-bootstrap/values.yaml
@@ -48,7 +48,7 @@ secretRef:
 keycloak:
   clientId: tdf-client
 
-  # override for global.opentdf.common.oidcExternalHost
+  # override for global.opentdf.common.oidcExternalBaseUrl
   hostname:
   # if provided, will use custom configuration instead
   customConfig: null

--- a/charts/keycloak-bootstrap/values.yaml
+++ b/charts/keycloak-bootstrap/values.yaml
@@ -26,8 +26,12 @@ global:
 # Is istio in place and requires a wait on the sidecar.
 istioTerminationHack: false
 
+# Deprecated. Use opentdf.externalUrl
+externalUrl:
+
 opentdf:
-  # Base URL for clients. Defaults to oidcExternalBaseUrl
+  # Base URL for clients. Defaults to oidcExternalBaseUrl. A client app's homepage
+  # Defaults to OIDC url without path attached.
   externalUrl:
   # A list of valid redirect paths. Defaults to externalUrl
   redirectUris:
@@ -43,6 +47,9 @@ secretRef:
 
 keycloak:
   clientId: tdf-client
+
+  # override for global.opentdf.common.oidcExternalHost
+  hostname:
   # if provided, will use custom configuration instead
   customConfig: null
   passwordUsers: testuser@virtru.com,user1,user2

--- a/charts/keycloak-bootstrap/values.yaml
+++ b/charts/keycloak-bootstrap/values.yaml
@@ -1,4 +1,3 @@
-name: "keycloak-bootstrap"
 replicaCount: 1
 job:
   backoffLimit: 25
@@ -42,8 +41,8 @@ opentdf:
 # - CLIENT_SECRET:
 # - ATTRIBUTES_USERNAME:
 # - ATTRIBUTES_PASSWORD:
-secretRef:
-  name: keycloak-bootstrap-secrets
+secretRef: |-
+  name: {{ template "keycloak-bootstrap.fullname" . }}-secret
 
 keycloak:
   clientId: tdf-client

--- a/charts/keycloak-bootstrap/values.yaml
+++ b/charts/keycloak-bootstrap/values.yaml
@@ -1,3 +1,6 @@
+# Select a specific name for the resource, instead of the default, keycloak-bootstrap
+nameOverride: ""
+
 replicaCount: 1
 job:
   backoffLimit: 25

--- a/charts/keycloak-bootstrap/values.yaml
+++ b/charts/keycloak-bootstrap/values.yaml
@@ -67,7 +67,7 @@ keycloak:
     # - username: user4
     #   password: testuser12345
 attributes:
-  hostname: http://opentdf-attributes
+  hostname: http://attributes
   realm: tdf
   clientId: dcr-test
   preloadedAuthorities: null
@@ -95,7 +95,7 @@ attributes:
   #   - C
   #   - D
 entitlements:
-  hostname: http://opentdf-entitlements
+  hostname: http://entitlements
   realms:
   - name: tdf
     clientId: dcr-test

--- a/charts/storage/templates/deployment.yaml
+++ b/charts/storage/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ include "storage.fullname" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ .Values.image.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}
@@ -36,7 +36,7 @@ spec:
           envFrom:
             {{- with .Values.secretRef }}
             - secretRef:
-                {{- toYaml . | nindent 16 }}
+                {{- tpl . $ | nindent 16 }}
             {{- end }}
             - configMapRef:
                 name: {{ include "storage.name" . }}-cm

--- a/charts/storage/templates/deployment.yaml
+++ b/charts/storage/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       labels:
         {{- include "storage.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.global.opentdf.common.imagePullSecrets }}
+      {{- with (coalesce .Values.imagePullSecrets .Values.global.opentdf.common.imagePullSecrets) }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/storage/values.yaml
+++ b/charts/storage/values.yaml
@@ -23,6 +23,10 @@ image:
   # The container's `imagePullPolicy`
   pullPolicy: IfNotPresent
 
+# JSON passed to the deployment's template.spec.imagePullSecrets.
+# Overrides global.opentdf.common.imagePullSecrets
+imagePullSecrets:
+
 # Select a specific name for the resource, instead of the default, opentdf-storage
 nameOverride: ""
 

--- a/charts/storage/values.yaml
+++ b/charts/storage/values.yaml
@@ -27,7 +27,7 @@ image:
 # Overrides global.opentdf.common.imagePullSecrets
 imagePullSecrets:
 
-# Select a specific name for the resource, instead of the default, opentdf-storage
+# Select a specific name for the resource, instead of the default, storage
 nameOverride: ""
 
 # The fully qualified appname override

--- a/charts/storage/values.yaml
+++ b/charts/storage/values.yaml
@@ -55,8 +55,8 @@ securityContext: {}
 # JSON to locate a k8s secret containing environment variables.
 # Notably, this file should include the following environemnt variable definitions:
 #     POSTGRES_PASSWORD: Password corresponding to postgres.user below
-secretRef:
-  name: storage-secrets
+secretRef: |-
+  name: {{ template "storage.fullname" . }}-secret
 
 # Service configuation information.
 service:

--- a/common.Tiltfile
+++ b/common.Tiltfile
@@ -165,7 +165,7 @@ def backend(extra_helm_parameters=[]):
         "ingress-nginx",
         repo_url="https://kubernetes.github.io/ingress-nginx",
         set=["controller.config.large-client-header-buffers=20 32k"],
-        version="4.0.16",
+        version="4.2.1",
     )
 
     k8s_resource("ingress-nginx-controller", port_forwards="65432:80")

--- a/common.Tiltfile
+++ b/common.Tiltfile
@@ -199,7 +199,7 @@ def backend(extra_helm_parameters=[]):
     # configurator scripts and the built-in bootstrap script.
     # Hopefully, either tilt or the helm_resource extension will be improved
     # to avoid this change (or maybe everything will just get faster)
-    update_settings(k8s_upsert_timeout_secs=300)
+    update_settings(k8s_upsert_timeout_secs=1200)
     helm_resource(
         name="backend",
         chart=BACKEND_DIR + "/charts/backend",
@@ -215,7 +215,7 @@ def backend(extra_helm_parameters=[]):
         ],
         image_keys=[
             ("keycloak-bootstrap.image.repo", "keycloak-bootstrap.image.tag"),
-            ("keycloakx.image.repository", "keycloakx.image.tag"),
+            ("keycloak.image.repository", "keycloak.image.tag"),
             ("attributes.image.repo", "attributes.image.tag"),
             ("entitlements.image.repo", "entitlements.image.tag"),
             ("entitlement_store.image.repo", "entitlement_store.image.tag"),

--- a/common.Tiltfile
+++ b/common.Tiltfile
@@ -5,7 +5,6 @@
 
 load("ext://helm_remote", "helm_remote")
 load("ext://helm_resource", "helm_resource", "helm_repo")
-load("ext://secret", "secret_from_dict", "secret_yaml_generic")
 load("ext://min_tilt_version", "min_tilt_version")
 
 min_tilt_version("0.30")

--- a/containers/entitlement-pdp/entitlement-policy/data.json
+++ b/containers/entitlement-pdp/entitlement-policy/data.json
@@ -1,7 +1,7 @@
 {
 	"opentdf": {
 		"entitlements_service": {
-			"url": "http://opentdf-entitlement-store:5000/entitle"
+			"url": "http://entitlement-store:5000/entitle"
 		}
 	}
 }

--- a/containers/keycloak-bootstrap/attributes_bootstrap.py
+++ b/containers/keycloak-bootstrap/attributes_bootstrap.py
@@ -99,7 +99,7 @@ def createPreloaded(
     attribute_username = os.getenv("ATTRIBUTES_USERNAME")
     attribute_password = os.getenv("ATTRIBUTES_PASSWORD")
     attribute_host = os.getenv(
-        "ATTRIBUTE_AUTHORITY_HOST", "http://opentdf-attributes:4020"
+        "ATTRIBUTE_AUTHORITY_HOST", "http://attributes:4020"
     ).rstrip("/")
 
     keycloak_openid = KeycloakOpenID(

--- a/containers/keycloak-bootstrap/entitlements_bootstrap.py
+++ b/containers/keycloak-bootstrap/entitlements_bootstrap.py
@@ -104,9 +104,9 @@ def insertEntitlementAttrsForRealm(
     # entitlement_clientid = os.getenv("ENTITLEMENT_CLIENT_ID")
     # entitlement_username = os.getenv("ENTITLEMENT_USERNAME")
     # entitlement_password = os.getenv("ENTITLEMENT_PASSWORD")
-    entitlement_host = os.getenv(
-        "ENTITLEMENT_HOST", "http://opentdf-entitlements:4030"
-    ).rstrip("/")
+    entitlement_host = os.getenv("ENTITLEMENT_HOST", "http://entitlements:4030").rstrip(
+        "/"
+    )
 
     keycloak_openid = KeycloakOpenID(
         # NOTE: `realm_name` IS NOT == `target_realm` here

--- a/containers/keycloak-protocol-mapper/EXAMPLES.md
+++ b/containers/keycloak-protocol-mapper/EXAMPLES.md
@@ -44,7 +44,7 @@ Example:
     ![Google IDP Token Exchage Policy](./readme-images/ehpolicy.png?raw=true)
 
     2. Verify new client policy is displayed   
-    
+
     ![Google IDP Token Exchage Policy](./readme-images/google_idp_wexhpolicy.png?raw=true)
 4. Add token exchange permission to keycloak client
     1. Goto token exchange permission 
@@ -55,9 +55,9 @@ Example:
     
     ![Client IDP Token Exchage Policy](./readme-images/client_expolicy.png?raw=true)
 5. Auth to Google and copy access token: - [google oauth2 playground](https://developers.google.com/oauthplayground/)
-                    
+
 6. Try it out
-    
+
     params:
     - client_id = keycloak client id
     - client_secret = keycloak client secret
@@ -71,7 +71,7 @@ Example:
       --url http://localhost:8080/auth/realms/master/protocol/openid-connect/token \
       --header 'content-type: application/x-www-form-urlencoded' \
       --data 'client_id=test&client_secret=$CLIENT_SECRET&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange&subject_token=$SUBJECT_TOKEN&subject_issuer=google&subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token&audience=test'
-    ```     
+    ```
 
 
 ### Identity Broker

--- a/tests/containers/clients/xtest.py
+++ b/tests/containers/clients/xtest.py
@@ -17,10 +17,14 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 tmp_dir = "tmp/"
 
-SDK_PATHS = {"py_service": "py/service.py", "py_encrypt": "py/encrypt.py", "py_decrypt": "py/decrypt.py"}
+SDK_PATHS = {
+    "py_service": "py/service.py",
+    "py_encrypt": "py/encrypt.py",
+    "py_decrypt": "py/decrypt.py",
+}
 
 KAS_ENDPOINT = os.getenv("KAS_ENDPOINT", "http://host.docker.internal:65432/kas")
-ATTRIBUTES_ENDPOINT = os.getenv("ATTRIBUTES_ENDPOINT", "http://opentdf-attributes:4020")
+ATTRIBUTES_ENDPOINT = os.getenv("ATTRIBUTES_ENDPOINT", "http://attributes:4020")
 OIDC_ENDPOINT = os.getenv("OIDC_ENDPOINT", "http://host.docker.internal:65432/keycloak")
 ORGANIZATION_NAME = "tdf"
 CLIENT_ID = "tdf-client"
@@ -31,22 +35,29 @@ ATTRIBUTES_CLIENT_SECRET = "123-456"
 CLIENTS = {
     CLIENT_ID: "123-456",
     TEST_CLIENT_1: "123-456-789",
-    TEST_CLIENT_2: "123-456-789"
+    TEST_CLIENT_2: "123-456-789",
 }
 ALL_OF_SUCCESS = ["http://testing123.fun/attr/Language/value/spanish"]
-ALL_OF_FAILURE = ["http://testing123.fun/attr/Language/value/spanish", "http://testing123.fun/attr/Language/value/french"]
-ANY_OF_SUCCESS = ["http://testing123.fun/attr/Color/value/green", "http://testing123.fun/attr/Color/value/blue"]
+ALL_OF_FAILURE = [
+    "http://testing123.fun/attr/Language/value/spanish",
+    "http://testing123.fun/attr/Language/value/french",
+]
+ANY_OF_SUCCESS = [
+    "http://testing123.fun/attr/Color/value/green",
+    "http://testing123.fun/attr/Color/value/blue",
+]
 ANY_OF_FAILURE = ["http://testing123.fun/attr/Color/value/blue"]
 HIERARCHY_SUCCESS = ["https://example.com/attr/Classification/value/U"]
 HIERARCHY_FAILURE = ["https://example.com/attr/Classification/value/TS"]
 ATTR_TESTS = {
-    "allOf": ALL_OF_SUCCESS, 
-    "allOf fail": ALL_OF_FAILURE, 
-    "anyOf": ANY_OF_SUCCESS, 
-    "anyOf fail": ANY_OF_FAILURE, 
-    "hierarchy": HIERARCHY_SUCCESS, 
-    "hierarchy fail": HIERARCHY_FAILURE
+    "allOf": ALL_OF_SUCCESS,
+    "allOf fail": ALL_OF_FAILURE,
+    "anyOf": ANY_OF_SUCCESS,
+    "anyOf fail": ANY_OF_FAILURE,
+    "hierarchy": HIERARCHY_SUCCESS,
+    "hierarchy fail": HIERARCHY_FAILURE,
 }
+
 
 def encrypt_web(ct_file, rt_file, attributes=None, client_id=CLIENT_ID):
     c = [
@@ -171,7 +182,9 @@ def teardown():
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Cross-test various TDF libraries and services.")
+    parser = argparse.ArgumentParser(
+        description="Cross-test various TDF libraries and services."
+    )
     parser.add_argument(
         "--large",
         help="Use a 5 GiB File; doesn't work with nano sdks",
@@ -210,11 +223,13 @@ def main():
         )
         if args.attrtest:
             logger.info("TDF3 ATTRIBUTE TESTS:")
-            failed += run_attribute_tests(tdf3_sdks_to_encrypt, tdf3_sdks_to_decrypt, pt_file)
+            failed += run_attribute_tests(
+                tdf3_sdks_to_encrypt, tdf3_sdks_to_decrypt, pt_file
+            )
             logger.info("NANO ATTRIBUTE TESTS:")
             failed += run_attribute_tests(
-            nano_sdks_to_encrypt, nano_sdks_to_decrypt, nano_pt_file
-        )
+                nano_sdks_to_encrypt, nano_sdks_to_decrypt, nano_pt_file
+            )
     finally:
         if not args.no_teardown:
             teardown()
@@ -233,6 +248,7 @@ def run_service_tests(service_test):
             failed += [f"{x}"]
     return failed
 
+
 def run_attribute_tests(sdks_encrypt, sdks_decrypt, pt_file):
     logger.info("--- run_attribute_tests %s => %s", sdks_encrypt, sdks_decrypt)
 
@@ -243,18 +259,32 @@ def run_attribute_tests(sdks_encrypt, sdks_decrypt, pt_file):
         for y in sdks_decrypt:
             serial_attr = 1
             for name, attrs in ATTR_TESTS.items():
-                rt_func = test_cross_roundtrip_failure if "fail" in name else test_cross_roundtrip
+                rt_func = (
+                    test_cross_roundtrip_failure
+                    if "fail" in name
+                    else test_cross_roundtrip
+                )
                 logger.info(f"Test #{serial}.{serial_attr}: {name}")
                 try:
-                    rt_func(x, y, f"{serial}.{serial_attr}", pt_file, attributes=attrs,
-                            encrypt_client=TEST_CLIENT_1, decrypt_client=TEST_CLIENT_2)
+                    rt_func(
+                        x,
+                        y,
+                        f"{serial}.{serial_attr}",
+                        pt_file,
+                        attributes=attrs,
+                        encrypt_client=TEST_CLIENT_1,
+                        decrypt_client=TEST_CLIENT_2,
+                    )
                 except Exception as e:
-                    logger.error("Exception with pass (%s => %s) %s", x, y, name, exc_info=True)
+                    logger.error(
+                        "Exception with pass (%s => %s) %s", x, y, name, exc_info=True
+                    )
                     failed += [f"{name} {x}=>{y}"]
                 finally:
                     serial_attr += 1
             serial += 1
     return failed
+
 
 def run_cli_tests(sdks_encrypt, sdks_decrypt, pt_file, attributes=None):
     logger.info("--- run_cli_tests %s => %s", sdks_encrypt, sdks_decrypt)
@@ -274,8 +304,15 @@ def run_cli_tests(sdks_encrypt, sdks_decrypt, pt_file, attributes=None):
 
 # Test a roundtrip across the two referenced sdks.
 # Returns True if test succeeded, false otherwise.
-def test_cross_roundtrip(encrypt_sdk, decrypt_sdk, serial, pt_file, attributes=None,
-     encrypt_client=CLIENT_ID, decrypt_client=CLIENT_ID):
+def test_cross_roundtrip(
+    encrypt_sdk,
+    decrypt_sdk,
+    serial,
+    pt_file,
+    attributes=None,
+    encrypt_client=CLIENT_ID,
+    decrypt_client=CLIENT_ID,
+):
     logger.info(
         "--- Begin Test #%s: Roundtrip encrypt(%s) --> decrypt(%s)",
         serial,
@@ -301,8 +338,15 @@ def test_cross_roundtrip(encrypt_sdk, decrypt_sdk, serial, pt_file, attributes=N
     logger.info("Test #%s, (%s->%s): Succeeded!", serial, encrypt_sdk, decrypt_sdk)
 
 
-def test_cross_roundtrip_failure(encrypt_sdk, decrypt_sdk, serial, pt_file, attributes=None,
-     encrypt_client=CLIENT_ID, decrypt_client=CLIENT_ID):
+def test_cross_roundtrip_failure(
+    encrypt_sdk,
+    decrypt_sdk,
+    serial,
+    pt_file,
+    attributes=None,
+    encrypt_client=CLIENT_ID,
+    decrypt_client=CLIENT_ID,
+):
     logger.info(
         "--- Begin Test #%s: Roundtrip encrypt(%s) --> decrypt(%s)",
         serial,
@@ -330,7 +374,7 @@ def test_cross_roundtrip_failure(encrypt_sdk, decrypt_sdk, serial, pt_file, attr
 
 def gen_pt(*, large):
     pt_file = "%stest-plain-%s.txt" % (tmp_dir, "large" if large else "small")
-    length = (5 * 2 ** 30) if large else 128
+    length = (5 * 2**30) if large else 128
     with open(pt_file, "w") as f:
         for i in range(0, length, 16):
             f.write("{:15,d}\n".format(i))

--- a/tests/integration/backend-keycloak-bootstrap-values.xtest.yaml
+++ b/tests/integration/backend-keycloak-bootstrap-values.xtest.yaml
@@ -1,5 +1,12 @@
 fullnameOverride: "xtest-keycloak-bootstrap"
 name: "xtest-keycloak-bootstrap"
+secretRef: |-
+  name: keycloak-bootstrap-otdf-secret
+global:
+  opentdf:
+    common:
+      oidcInternalBaseUrl: http://keycloak-http
+      oidcUrlPath: auth
 keycloak:
   customConfig:  
   - name: tdf
@@ -90,7 +97,7 @@ keycloak:
           type: password
 
 attributes:
-  hostname: http://opentdf-attributes:4020
+  hostname: http://attributes:4020
   realm: tdf
   clientId: dcr-test
   username: user1
@@ -119,7 +126,7 @@ attributes:
 
 
 entitlements:
-  hostname: http://opentdf-entitlements:4030
+  hostname: http://entitlements:4030
   realms:
   - name: tdf
     clientId: dcr-test

--- a/tests/integration/backend-keycloak-bootstrap-values.xtest.yaml
+++ b/tests/integration/backend-keycloak-bootstrap-values.xtest.yaml
@@ -5,7 +5,7 @@ keycloak:
   - name: tdf
     payload:
       realm: tdf
-      enabled: "true"      
+      enabled: "true"
     clients:
     - payload:
         clientId: test-client-1
@@ -87,7 +87,7 @@ keycloak:
         enabled: "true"
         credentials:
         - value: testuser123
-          type: password          
+          type: password
 
 attributes:
   hostname: http://opentdf-attributes:4020
@@ -125,7 +125,7 @@ entitlements:
     clientId: dcr-test
     username: user1
     password: testuser123
-    preloadedClaims:            
+    preloadedClaims:
       test-client-1:
         - http://testing123.fun/attr/Language/value/french
         - http://testing123.fun/attr/Language/value/spanish
@@ -135,7 +135,7 @@ entitlements:
         - https://example.com/attr/Classification/value/C
         - http://testing123.fun/attr/Language/value/spanish
         - http://testing123.fun/attr/Color/value/green
-      
+
 externalUrl: http://localhost:65432
 
 job:

--- a/tests/integration/backend-pki-values.yaml
+++ b/tests/integration/backend-pki-values.yaml
@@ -10,7 +10,7 @@ kas:
           pathType: Prefix
       host.docker.internal: *paths
 
-keycloakx:
+keycloak:
   fullnameOverride: keycloak
   image:
     # Keycloak is a non-OpenTDF chart, but with an OpenTDF image

--- a/tests/integration/backend-pki-values.yaml
+++ b/tests/integration/backend-pki-values.yaml
@@ -68,6 +68,7 @@ keycloak:
       value: -Djgroups.dns.query={{ include "keycloak.fullname" . }}-headless
   ingress:
     enabled: true
+    # TODO: Fix usage with other rest endpoints
     ingressClassName: nginx
     servicePort: https
     rules:
@@ -75,12 +76,13 @@ keycloak:
         host: "keycloak-http"
         # Paths for the host
         paths:
-          - path: /
+          - path: /auth(/|$)(.*)
             pathType: Prefix
     annotations:
       kubernetes.io/tls-acme: "true"
       ingress.kubernetes.io/affinity: cookie
       nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+      nginx.ingress.kubernetes.io/rewrite-target: /auth/$2
       nginx.ingress.kubernetes.io/proxy-ssl-secret: "default/x509-secret"
       nginx.ingress.kubernetes.io/proxy-ssl-verify: "off"
       nginx.ingress.kubernetes.io/proxy-ssl-verify-depth: "2"

--- a/tests/integration/backend-pki-values.yaml
+++ b/tests/integration/backend-pki-values.yaml
@@ -15,7 +15,7 @@ keycloak:
   image:
     # Keycloak is a non-OpenTDF chart, but with an OpenTDF image
     repository: ghcr.io/opentdf/keycloak
-    tag: head
+    tag: main
     pullPolicy: IfNotPresent
   command:
     - "/opt/keycloak/bin/kc.sh"
@@ -29,11 +29,11 @@ keycloak:
     - name: KC_LOG_LEVEL
       value: INFO
     - name: CLAIMS_URL
-      value: http://opentdf-entitlement-pdp:3355/entitlements
+      value: http://entitlement-pdp:3355/entitlements
     - name: KC_DB
       value: postgres
     - name: KC_DB_URL_HOST
-      value: opentdf-postgresql
+      value: postgresql
     - name: KC_DB_URL_DATABASE
       value: keycloak_database
     - name: KC_DB_URL_PORT

--- a/tests/integration/backend-xtest-values.yaml
+++ b/tests/integration/backend-xtest-values.yaml
@@ -71,7 +71,7 @@ keycloak-bootstrap:
                   type: password
 
   attributes:
-    hostname: http://opentdf-attributes:4020
+    hostname: http://attributes:4020
     realm: tdf
     clientId: dcr-test
     username: user1
@@ -99,7 +99,7 @@ keycloak-bootstrap:
           - portuguese
 
   entitlements:
-    hostname: http://opentdf-entitlements:4030
+    hostname: http://entitlements:4030
     realms:
       - name: tdf
         clientId: dcr-test

--- a/tests/integration/xtest.yaml
+++ b/tests/integration/xtest.yaml
@@ -18,7 +18,7 @@ spec:
           imagePullPolicy: IfNotPresent
           env:
             - name: KAS_ENDPOINT
-              value: http://opentdf-kas:8000
+              value: http://kas:8000
             - name: OIDC_ENDPOINT
               value: http://keycloak-http
       restartPolicy: Never

--- a/tests/performance-test/fast-api-client/README.md
+++ b/tests/performance-test/fast-api-client/README.md
@@ -47,10 +47,9 @@ Things to know:
     1. `sync_detailed`: Blocking request that always returns a `Request`, optionally with `parsed` set if the request was successful.
     1. `asyncio`: Like `sync` but the async instead of blocking
     1. `asyncio_detailed`: Like `sync_detailed` by async instead of blocking
-     
 1. All path/query params, and bodies become method arguments.
 1. If your endpoint had any tags on it, the first tag will be used as a module name for the function (my_tag above)
-1. Any endpoint which did not have a tag will be in `fast_api_client.api.default`    
+1. Any endpoint which did not have a tag will be in `fast_api_client.api.default`
 
 ## Building / publishing this Client
 This project uses [Poetry](https://python-poetry.org/) to manage dependencies  and packaging.  Here are the basics:

--- a/tests/security-test/helm-test.sh
+++ b/tests/security-test/helm-test.sh
@@ -1,5 +1,3 @@
-
-
 helm repo add secureCodeBox https://charts.securecodebox.io
 
 # Create a new namespace for the secureCodeBox Operator
@@ -7,7 +5,6 @@ kubectl create namespace securecodebox-system
 
 # Install the Operator & CRD's
 helm --namespace securecodebox-system upgrade --install securecodebox-operator --version 3.1.1 secureCodeBox/operator
-
 
 helm upgrade --install zap-advanced secureCodeBox/zap-advanced
 
@@ -22,12 +19,12 @@ data:
   2-zap-advanced-scan-${service_name}.yaml: |-
     contexts:
       - name: scb-context-${service_name}
-        url: http://opentdf-${service}/
+        url: http://${service}/
     apis:
       - name: scb-api-${service_name}
         context: scb-context-${service_name}
         format: openapi
-        url: http://opentdf-${service}/openapi.json
+        url: http://${service}/openapi.json
 ---
 apiVersion: "execution.securecodebox.io/v1"
 kind: Scan
@@ -39,7 +36,7 @@ spec:
   scanType: "zap-advanced-scan"
   parameters:
     - "-t"
-    - "http://opentdf-${service}/"
+    - "http://${service}/"
     - "-r"
     - "HTML"
   volumeMounts:

--- a/xtest.Tiltfile
+++ b/xtest.Tiltfile
@@ -13,7 +13,7 @@ k8s_yaml(
         values=["./tests/integration/backend-keycloak-bootstrap-values.xtest.yaml"],
         set=[
             "secrets.oidcClientSecret=%s" % OIDC_CLIENT_SECRET,
-            "global.opentdf.common.oidcInternalHost=http://keycloak-http",
+            "global.opentdf.common.oidcInternalBaseUrl=http://keycloak-http",
             "global.opentdf.common.oidcUrlPath=auth",
             "image.repo=" + CONTAINER_REGISTRY + "/opentdf/keycloak-bootstrap",
         ],

--- a/xtest.Tiltfile
+++ b/xtest.Tiltfile
@@ -13,8 +13,6 @@ k8s_yaml(
         values=["./tests/integration/backend-keycloak-bootstrap-values.xtest.yaml"],
         set=[
             "secrets.oidcClientSecret=%s" % OIDC_CLIENT_SECRET,
-            "global.opentdf.common.oidcInternalBaseUrl=http://keycloak-http",
-            "global.opentdf.common.oidcUrlPath=auth",
             "image.repo=" + CONTAINER_REGISTRY + "/opentdf/keycloak-bootstrap",
         ],
     )


### PR DESCRIPTION
changes: _rev_

### NO_REF

- Updates all 'global' parameters to allow being set on a per-chart basis
- This fixes backward-compatibility with 1.0.0 versions of the charts that don't have globals, and allows more customization
- However, not all of the charts map cleanly, notably there may be issues with some logic about the presence of the `auth/` suffix on the oidc path, for example
- Prefer using the `fullname` templates where appropriate over `.Chart.Name` or similar.
- Updates several _helpers to more recent versions of the templates
- Take advantage of `tpl`, as found in codecentric and bitnami charts, to allow dynamic setting of secret names based on chart name.
- Small template fixups, such as removing no-op `default` functions, stray white space, and so on

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
