### PR TITLE
Refactor confusing oidc value keys and fix keycloakX HOSTNAME secret gen

### DIFF
--- a/charts/attributes/templates/_helpers.tpl
+++ b/charts/attributes/templates/_helpers.tpl
@@ -66,9 +66,9 @@ Create OIDC Internal Url from a common value
 */}}
 {{- define "attributes.oidc.internalUrl" }}
 {{- if .Values.global.opentdf.common.oidcUrlPath }}
-{{- printf "%s/%s" .Values.global.opentdf.common.oidcInternalHost .Values.global.opentdf.common.oidcUrlPath }}
+{{- printf "%s/%s" .Values.global.opentdf.common.oidcInternalBaseUrl .Values.global.opentdf.common.oidcUrlPath }}
 {{- else }}
-{{- default .Values.global.opentdf.common.oidcInternalHost }}
+{{- default .Values.global.opentdf.common.oidcInternalBaseUrl }}
 {{- end }}
 {{- end }}
 
@@ -78,8 +78,8 @@ Create OIDC External Url from a common value
 */}}
 {{- define "attributes.oidc.externalUrl" }}
 {{- if .Values.global.opentdf.common.oidcUrlPath }}
-{{- printf "%s/%s" .Values.global.opentdf.common.oidcExternalHost .Values.global.opentdf.common.oidcUrlPath }}
+{{- printf "%s/%s" .Values.global.opentdf.common.oidcExternalBaseUrl .Values.global.opentdf.common.oidcUrlPath }}
 {{- else }}
-{{- default .Values.global.opentdf.common.oidcExternalHost }}
+{{- default .Values.global.opentdf.common.oidcExternalBaseUrl }}
 {{- end }}
 {{- end }}

--- a/charts/attributes/values.yaml
+++ b/charts/attributes/values.yaml
@@ -2,8 +2,8 @@
 global:
   opentdf:
     common:
-      oidcInternalHost: http://keycloak-http
-      oidcExternalHost: http://localhost:65432
+      oidcInternalBaseUrl: http://keycloak-http
+      oidcExternalBaseUrl: http://localhost:65432
       oidcUrlPath: auth
       # JSON passed to the deployment's template.spec.imagePullSecrets
       imagePullSecrets: []

--- a/charts/backend/templates/_helpers.tpl
+++ b/charts/backend/templates/_helpers.tpl
@@ -35,9 +35,20 @@ Create Keycloak External Url
 */}}
 {{- define "backend.keycloak.externalUrl" }}
 {{- if .Values.global.opentdf.common.oidcUrlPath }}
-{{- printf "%s/%s" .Values.global.opentdf.common.oidcExternalHost .Values.global.opentdf.common.oidcUrlPath }}
+{{- printf "%s/%s" .Values.global.opentdf.common.oidcExternalBaseUrl .Values.global.opentdf.common.oidcUrlPath }}
 {{- else }}
-{{- default .Values.global.opentdf.common.oidcExternalHost }}
+{{- default .Values.global.opentdf.common.oidcExternalBaseUrl }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create Keycloak hostname by extracting from the external url base .Values.global.opentdf.common.oidcExternalBaseUrl
+*/}}
+{{- define "backend.keycloak.externalHostname" }}
+{{- if hasPrefix "http://" .Values.global.opentdf.common.oidcExternalBaseUrl }}
+{{- default ( trimPrefix "http://" .Values.global.opentdf.common.oidcExternalBaseUrl ) }}
+{{- else }}
+{{- default ( trimPrefix "https://" .Values.global.opentdf.common.oidcExternalBaseUrl ) }}
 {{- end }}
 {{- end }}
 

--- a/charts/backend/templates/secrets.yaml
+++ b/charts/backend/templates/secrets.yaml
@@ -11,8 +11,8 @@ type: Opaque
 stringData:
   KEYCLOAK_ADMIN: {{ .Values.global.opentdf.common.keycloak.user }}
   KEYCLOAK_ADMIN_PASSWORD: {{ .Values.global.opentdf.common.keycloak.password}}
-  KC_HOSTNAME: {{ ( include "backend.keycloak.externalUrl" . ) | quote }}
-  KC_HOSTNAME_ADMIN: {{ ( include "backend.keycloak.externalUrl" . ) | quote }}
+  KC_HOSTNAME: {{ ( include "backend.keycloak.externalHostname" . ) | quote }}
+  KC_HOSTNAME_ADMIN: {{ ( include "backend.keycloak.externalHostname" . ) | quote }}
   KC_DB_USERNAME: "keycloak_manager"
   KC_DB_PASSWORD: {{ .Values.secrets.postgres.dbPassword }}
   KC_DB_URL_HOST: {{ .Values.global.opentdf.common.postgres.host }}

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -10,13 +10,12 @@ boostrapKeycloak: true
 global:
   opentdf:
     common:
-      externalUrl: http://localhost:65432
       # The cluster internal scheme + hostname for keycloak endpoint, oidcUrlPrefix used in constructing end urls.
-      oidcInternalHost: http://keycloak-http
-      # The url path (no precedding / ) to keycloak
+      oidcInternalBaseUrl: http://keycloak-http
+      # The url path (no preceding / ) to keycloak
       oidcUrlPath: auth
       # The external scheme + hostname to keycloak endpoint, oidcUrlPrefix used in constructing end urls.
-      oidcExternalHost: http://localhost:65432
+      oidcExternalBaseUrl: http://localhost:65432
       # Any existing image pull secrets subcharts should use
       # e.g.
       # imagePullSecrets:

--- a/charts/entitlements/templates/_helpers.tpl
+++ b/charts/entitlements/templates/_helpers.tpl
@@ -68,9 +68,9 @@ Create OIDC Internal Url from a common value
 */}}
 {{- define "entitlements.oidc.internalUrl" }}
 {{- if .Values.global.opentdf.common.oidcUrlPath }}
-{{- printf "%s/%s" .Values.global.opentdf.common.oidcInternalHost .Values.global.opentdf.common.oidcUrlPath }}
+{{- printf "%s/%s" .Values.global.opentdf.common.oidcInternalBaseUrl .Values.global.opentdf.common.oidcUrlPath }}
 {{- else }}
-{{- default .Values.global.opentdf.common.oidcInternalHost }}
+{{- default .Values.global.opentdf.common.oidcInternalBaseUrl }}
 {{- end }}
 {{- end }}
 
@@ -80,8 +80,8 @@ Create OIDC External Url from a common value
 */}}
 {{- define "entitlements.oidc.externalUrl" }}
 {{- if .Values.global.opentdf.common.oidcUrlPath }}
-{{- printf "%s/%s" .Values.global.opentdf.common.oidcExternalHost .Values.global.opentdf.common.oidcUrlPath }}
+{{- printf "%s/%s" .Values.global.opentdf.common.oidcExternalBaseUrl .Values.global.opentdf.common.oidcUrlPath }}
 {{- else }}
-{{- default .Values.global.opentdf.common.oidcExternalHost }}
+{{- default .Values.global.opentdf.common.oidcExternalBaseUrl }}
 {{- end }}
 {{- end }}

--- a/charts/entitlements/values.yaml
+++ b/charts/entitlements/values.yaml
@@ -2,8 +2,8 @@
 global:
   opentdf:
     common:
-      oidcInternalHost: http://keycloak-http
-      oidcExternalHost: http://localhost:65432
+      oidcInternalBaseUrl: http://keycloak-http
+      oidcExternalBaseUrl: http://localhost:65432
       oidcUrlPath: auth
       # JSON passed to the deployment's template.spec.imagePullSecrets
       imagePullSecrets: []

--- a/charts/entity-resolution/templates/_helpers.tpl
+++ b/charts/entity-resolution/templates/_helpers.tpl
@@ -34,5 +34,5 @@ Create chart name and version as used by the chart label.
 Create OIDC Internal Url from a common value   
 */}}
 {{- define "entityresolution.keycloakUrl" }}
-{{- default .Values.global.opentdf.common.oidcInternalHost }}
+{{- default .Values.global.opentdf.common.oidcInternalBaseUrl }}
 {{- end }}

--- a/charts/entity-resolution/values.yaml
+++ b/charts/entity-resolution/values.yaml
@@ -4,7 +4,7 @@ name: 'opentdf-entity-resolution'
 global:
   opentdf:
     common:
-      oidcInternalHost: "http://keycloak-http"
+      oidcInternalBaseUrl: "http://keycloak-http"
       # JSON passed to the deployment's template.spec.imagePullSecrets
       imagePullSecrets: []
 

--- a/charts/kas/templates/_helpers.tpl
+++ b/charts/kas/templates/_helpers.tpl
@@ -66,7 +66,7 @@ Create the name of the service account to use
 Create oidc endpoint from a common value    
 */}}
 {{- define "kas.oidcPubkeyEndpoint" }}
-{{- default .Values.global.opentdf.common.oidcInternalHost }}
+{{- default .Values.global.opentdf.common.oidcInternalBaseUrl }}
 {{- end }}
 
 {{- define "kas.secretName" -}}

--- a/charts/kas/values.yaml
+++ b/charts/kas/values.yaml
@@ -2,7 +2,7 @@
 global:
   opentdf:
     common:
-      oidcInternalHost: http://localhost:65432
+      oidcInternalBaseUrl: http://localhost:65432
       # JSON passed to the deployment's template.spec.imagePullSecrets
       imagePullSecrets: []
 

--- a/charts/keycloak-bootstrap/templates/_helpers.tpl
+++ b/charts/keycloak-bootstrap/templates/_helpers.tpl
@@ -42,9 +42,9 @@ Create OIDC Internal Url from a common value (if it exists)
 */}}
 {{- define "bootstrap.oidc.internalUrl" }}
 {{- if .Values.global.opentdf.common.oidcUrlPath }}
-{{- printf "%s/%s" .Values.global.opentdf.common.oidcInternalHost .Values.global.opentdf.common.oidcUrlPath }}
+{{- printf "%s/%s" .Values.global.opentdf.common.oidcInternalBaseUrl .Values.global.opentdf.common.oidcUrlPath }}
 {{- else }}
-{{- default .Values.global.opentdf.common.oidcInternalHost }}
+{{- default .Values.global.opentdf.common.oidcInternalBaseUrl }}
 {{- end }}
 {{- end }}
 
@@ -52,7 +52,7 @@ Create OIDC Internal Url from a common value (if it exists)
 Create OIDC External Url from a common value (if it exists)
 */}}
 {{- define "bootstrap.oidc.externalUrl" }}
-{{- $extHost := .Values.global.opentdf.common.oidcExternalHost }}
+{{- $extHost := .Values.global.opentdf.common.oidcExternalBaseUrl }}
 {{- if .Values.global.opentdf.common.oidcUrlPath }}
 {{- printf "%s/%s" $extHost .Values.global.opentdf.common.oidcUrlPath }}
 {{- else }}
@@ -64,13 +64,13 @@ Create OIDC External Url from a common value (if it exists)
 The base URL for clients by default
 */}}
 {{- define "bootstrap.opentdf.externalUrl" }}
-{{- .Values.opentdf.externalUrl | default .Values.global.opentdf.common.oidcExternalHost }}
+{{- .Values.opentdf.externalUrl | default .Values.global.opentdf.common.oidcExternalBaseUrl }}
 {{- end }}
 
 {{/*
 Valid redirect URIs
 */}}
 {{- define "bootstrap.opentdf.redirectUris" }}
-{{- $defHost := (.Values.opentdf.externalUrl | default .Values.global.opentdf.common.oidcExternalHost) }}
+{{- $defHost := (.Values.opentdf.externalUrl | default .Values.global.opentdf.common.oidcExternalBaseUrl) }}
 {{- join " " .Values.opentdf.redirectUris | default (printf "%s/*" $defHost) }}
 {{- end }}

--- a/charts/keycloak-bootstrap/values.yaml
+++ b/charts/keycloak-bootstrap/values.yaml
@@ -17,8 +17,8 @@ pki:
 global:
   opentdf:
     common:
-      oidcInternalHost: http://keycloak-http
-      oidcExternalHost: http://localhost:65432
+      oidcInternalBaseUrl: http://keycloak-http
+      oidcExternalBaseUrl: http://localhost:65432
       oidcUrlPath: auth
       # JSON passed to the deployment's template.spec.imagePullSecrets
       imagePullSecrets: []
@@ -27,7 +27,7 @@ global:
 istioTerminationHack: false
 
 opentdf:
-  # Base URL for clients. Defaults to oidcExternalHost
+  # Base URL for clients. Defaults to oidcExternalBaseUrl
   externalUrl:
   # A list of valid redirect paths. Defaults to externalUrl
   redirectUris:


### PR DESCRIPTION
Refactor common helm value names to reflect their use:
oidcInternalHost -> oidcInternalUrl
oidcExternalHost -> oidcExternalBaseUrl

KC HOSTNAME should be hostname only, so adding template backend.keycloak.externalHostname sourced from trimPrefix of oidcExternalBaseUrl 
