### PR TITLE
PLAT-1946 Abacus: Unclear 500 error is returned when Delete Authority is failed due to existing attributes.

### DIFF
--- a/containers/attributes/main.py
+++ b/containers/attributes/main.py
@@ -981,7 +981,7 @@ async def delete_authorities_crud(request):
     except ForeignKeyViolationError as e:
         raise HTTPException(
             status_code=status.HTTP_405_METHOD_NOT_ALLOWED,
-            detail=f"Delete failed due to foreign-key constraint: {str(e)}"
+            detail=f"Unable to delete non-empty authority"
         ) from e
     return {}
 


### PR DESCRIPTION
PLAT-1946 Abacus: Unclear 500 error is returned when Delete Authority is failed due to existing attributes.

changes: _rev_

### Proposed Changes
_Please use the Jira Key or NOREF followd by the changes_

- Issue #5432
  - Some change
  - Another change

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
