### PR TITLE
🛠 Add toggle able ingress defaults to ☂️📈

### DIFF
--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -64,7 +64,6 @@ attributes:
       localhost: &pathsAttributes
         "/api/attributes(/|$)(.*)":
           pathType: Prefix
-      host.docker.internal: *pathsAttributes
       opentdf.local: *pathsAttributes
 entitlement-pdp:
   fullnameOverride: entitlement-pdp
@@ -95,7 +94,6 @@ entitlements:
       localhost: &pathsEntitlements
         "/api/entitlements(/|$)(.*)":
           pathType: Prefix
-      host.docker.internal: *pathsEntitlements
       opentdf.local: *pathsEntitlements
 entity-resolution:
   fullnameOverride: entity-resolution
@@ -114,7 +112,7 @@ kas:
     ecPrivKey:
     privKey:
   ingress:
-    enabled: true
+    enabled: false
     annotations:
       nginx.ingress.kubernetes.io/rewrite-target: /$2
     className: nginx
@@ -122,7 +120,6 @@ kas:
       localhost: &pathsKas
         "/api/kas(/|$)(.*)":
           pathType: Prefix
-      host.docker.internal: *pathsKas
       opentdf.local: *pathsKas
   logLevel: DEBUG
   pdp:
@@ -169,7 +166,7 @@ keycloak:
     - secretRef:
         name: "{{ include "keycloak.fullname" . }}-otdf-secret"
   ingress:
-    enabled: true
+    enabled: false
     ingressClassName: nginx
     annotations:
       nginx.ingress.kubernetes.io/rewrite-target: /auth/$2
@@ -178,10 +175,6 @@ keycloak:
         paths: &paths
           - path: /auth(/|$)(.*)
             pathType: Prefix
-      - host: host.docker.internal
-        paths: *paths
-      - host: offline.demo.internal
-        paths: *paths
       - host: opentdf.local
         paths: *paths
     tls: []

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -55,6 +55,17 @@ attributes:
   fullnameOverride: attributes
   secretRef: |-
     name: "{{ template "attributes.fullname" . }}-otdf-secret"
+  ingress:
+    enabled: false
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: /$2
+    className: nginx
+    hosts:
+      localhost: &pathsAttributes
+        "/api/attributes(/|$)(.*)":
+          pathType: Prefix
+      host.docker.internal: *pathsAttributes
+      opentdf.local: *pathsAttributes
 entitlement-pdp:
   fullnameOverride: entitlement-pdp
   opaConfig:
@@ -75,6 +86,17 @@ entitlements:
   fullnameOverride: entitlements
   secretRef: |-
     name: "{{ template "entitlements.fullname" . }}-otdf-secret"
+  ingress:
+    enabled: false
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: /$2
+    className: nginx
+    hosts:
+      localhost: &pathsEntitlements
+        "/api/entitlements(/|$)(.*)":
+          pathType: Prefix
+      host.docker.internal: *pathsEntitlements
+      opentdf.local: *pathsEntitlements
 entity-resolution:
   fullnameOverride: entity-resolution
   config:
@@ -91,6 +113,17 @@ kas:
     cert:
     ecPrivKey:
     privKey:
+  ingress:
+    enabled: true
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: /$2
+    className: nginx
+    hosts:
+      localhost: &pathsKas
+        "/api/kas(/|$)(.*)":
+          pathType: Prefix
+      host.docker.internal: *pathsKas
+      opentdf.local: *pathsKas
   logLevel: DEBUG
   pdp:
     verbose: "true"


### PR DESCRIPTION
changes: _rev_

### Proposed Changes
_Please use the Jira Key or NOREF followd by the changes_

- kas and other microservice ingresses is required to do a lot of our demos, and this gives some examples
- Disables the keycloak ingress by default, to match the others
- For now, allowed names are just `localhost` and `opentdf.local`. Thoughts?

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
