### PR TITLE
🧹 Remove old helm classic labels

### DIFF
--- a/charts/attributes/templates/configmap.yaml
+++ b/charts/attributes/templates/configmap.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "attributes.fullname" . }}-cm
+  labels:
+    {{- include "attributes.labels" . | nindent 4 }}
 data:
   # TODO /auth and /token are well-known and can be hardcoded
   # we do not need two config properties for this - just one.

--- a/charts/backend/templates/_helpers.tpl
+++ b/charts/backend/templates/_helpers.tpl
@@ -31,6 +31,26 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Common labels
+*/}}
+{{- define "backend.labels" -}}
+helm.sh/chart: {{ include "backend.chart" . }}
+{{ include "backend.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "backend.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "backend.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
 Create Keycloak External Url   
 */}}
 {{- define "backend.keycloak.externalUrl" }}

--- a/charts/backend/templates/postgres-initdb-secret.yaml
+++ b/charts/backend/templates/postgres-initdb-secret.yaml
@@ -7,10 +7,7 @@ kind: Secret
 metadata:
   name: {{ $fullName }}-initdb-secret
   labels:
-    app: {{ .Chart.Name | quote }}
-    chart: {{ include "backend.chart" . | quote}}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}  
+    {{- include "backend.labels" . | nindent 4 }}
 type: Opaque    
 stringData:
   init.sql: |

--- a/charts/backend/templates/secrets.yaml
+++ b/charts/backend/templates/secrets.yaml
@@ -4,10 +4,7 @@ kind: Secret
 metadata:
   name: {{ include "keycloak.fullname" .Subcharts.keycloak }}-otdf-secret
   labels:
-    app: {{ .Chart.Name | quote }}
-    chart: {{ include "backend.chart" . | quote }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "backend.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   KEYCLOAK_ADMIN: {{ .Values.global.opentdf.common.keycloak.user }}
@@ -26,10 +23,7 @@ kind: Secret
 metadata:
   name: {{ template "postgresql.primary.fullname" .Subcharts.postgresql }}-otdf-secret
   labels:
-    app: {{ .Chart.Name | quote }}
-    chart: {{ include "backend.chart" . | quote }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "backend.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   postgresql-password: {{ .Values.secrets.postgres.dbPassword }}
@@ -40,10 +34,7 @@ kind: Secret
 metadata:
   name: {{ include "attributes.fullname" .Subcharts.attributes }}-otdf-secret
   labels:
-    app: {{ .Chart.Name | quote }}
-    chart: {{ include "backend.chart" . | quote }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "backend.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   POSTGRES_PASSWORD: {{ .Values.secrets.postgres.dbPassword }}
@@ -55,10 +46,7 @@ kind: Secret
 metadata:
   name: {{ index .Subcharts "keycloak-bootstrap" | include "keycloak-bootstrap.fullname" }}-otdf-secret
   labels:
-    app: {{ .Chart.Name | quote }}
-    chart: {{ include "backend.chart" . | quote }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "backend.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   CLIENT_SECRET: {{ .Values.secrets.keycloakBootstrap.clientSecret }}
@@ -73,10 +61,7 @@ kind: Secret
 metadata:
   name: {{ index .Subcharts "entitlement-store" | include "entitlement-store.fullname" }}-otdf-secret
   labels:
-    app: {{ .Chart.Name | quote }}
-    chart: {{ include "backend.chart" . | quote }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "backend.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   POSTGRES_PASSWORD: {{ .Values.secrets.postgres.dbPassword }}
@@ -86,10 +71,7 @@ kind: Secret
 metadata:
   name: {{ index .Subcharts "entitlement-pdp" | include "entitlement-pdp.fullname" }}-otdf-secret
   labels:
-    app: {{ .Chart.Name | quote }}
-    chart: {{ include "backend.chart" . | quote }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "backend.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   opaPolicyPullSecret: {{ .Values.secrets.opaPolicyPullSecret }}
@@ -99,10 +81,7 @@ kind: Secret
 metadata:
   name: {{ index .Subcharts "entitlements" | include "entitlements.fullname" }}-otdf-secret
   labels:
-    app: {{ .Chart.Name | quote }}
-    chart: {{ include "backend.chart" . | quote }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "backend.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   POSTGRES_PASSWORD: {{ .Values.secrets.postgres.dbPassword }}

--- a/charts/entitlement-pdp/templates/_helpers.tpl
+++ b/charts/entitlement-pdp/templates/_helpers.tpl
@@ -29,3 +29,34 @@ Create chart name and version as used by the chart label.
 {{- define "entitlement-pdp.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "entitlement-pdp.labels" -}}
+helm.sh/chart: {{ include "entitlement-pdp.chart" . }}
+{{ include "entitlement-pdp.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "entitlement-pdp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "entitlement-pdp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "entitlement-pdp.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "entitlement-pdp.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/entitlement-pdp/templates/configmap.yaml
+++ b/charts/entitlement-pdp/templates/configmap.yaml
@@ -3,10 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "entitlement-pdp.fullname" . }}-cm
   labels:
-    app: {{ .Chart.Name | quote }}
-    chart: {{ include "entitlement-pdp.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "entitlement-pdp.labels" . | nindent 4 }}
 data:
   listenPort: {{ .Values.config.listenPort | quote }}
   externalHost: {{ .Values.config.externalHost | quote }}

--- a/charts/entitlement-pdp/templates/deployment.yaml
+++ b/charts/entitlement-pdp/templates/deployment.yaml
@@ -6,24 +6,20 @@ metadata:
   annotations:
     proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
   labels:
-    app: {{ .Chart.Name | quote }}
-    chart: {{ include "entitlement-pdp.chart" . | quote }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "entitlement-pdp.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ .Chart.Name | quote }}
-      release: {{ .Release.Name }}
+      {{- include "entitlement-pdp.selectorLabels" . | nindent 6 }}
   strategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-        app: {{ .Chart.Name | quote }}
-        release: {{ .Release.Name }}
+        {{- include "entitlement-pdp.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "entitlement-pdp.serviceAccountName" . }}
       containers:
       - name: {{ include "entitlement-pdp.fullname" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/entitlement-pdp/templates/secret.yaml
+++ b/charts/entitlement-pdp/templates/secret.yaml
@@ -4,10 +4,7 @@ kind: Secret
 metadata:
   name: {{ include "entitlement-pdp.fullname" . }}-secret
   labels:
-    app: {{ .Chart.Name | quote }}
-    chart: {{ include "entitlement-pdp.chart" . | quote }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "entitlement-pdp.labels" . | nindent 4 }}
 type: Opaque
 data:
   opaPolicyPullSecret: {{ .Values.secret.opaPolicyPullSecret | b64enc }}

--- a/charts/entitlement-pdp/templates/service.yaml
+++ b/charts/entitlement-pdp/templates/service.yaml
@@ -11,5 +11,4 @@ spec:
     appProtocol: http
     targetPort: {{ .Values.config.listenPort }}
   selector:
-  labels:
     {{- include "entitlement-pdp.selectorLabels" . | nindent 4 }}

--- a/charts/entitlement-pdp/templates/service.yaml
+++ b/charts/entitlement-pdp/templates/service.yaml
@@ -3,9 +3,7 @@ kind: Service
 metadata:
   name: {{ include "entitlement-pdp.fullname" . }}
   labels:
-    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
-    release: "{{ $.Release.Name }}"
-    heritage: "{{ $.Release.Service }}"
+    {{- include "entitlement-pdp.labels" . | nindent 4 }}
 spec:
   ports:
   - port: {{ .Values.config.listenPort }}
@@ -13,4 +11,5 @@ spec:
     appProtocol: http
     targetPort: {{ .Values.config.listenPort }}
   selector:
-    app: {{ .Chart.Name | quote }}
+  labels:
+    {{- include "entitlement-pdp.selectorLabels" . | nindent 4 }}

--- a/charts/entitlement-pdp/templates/serviceaccount.yaml
+++ b/charts/entitlement-pdp/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "entitlement-pdp.serviceAccountName" . }}
+  labels:
+    {{- include "entitlement-pdp.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/entitlement-pdp/values.yaml
+++ b/charts/entitlement-pdp/values.yaml
@@ -16,6 +16,15 @@ image:
 # Overrides global.opentdf.common.imagePullSecrets when set
 imagePullSecrets:
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 secret:
   opaPolicyPullSecret: "YOUR_GHCR_PAT_HERE"
 

--- a/charts/entitlement-store/templates/configmap.yaml
+++ b/charts/entitlement-store/templates/configmap.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "entitlement-store.name" . }}-cm
+  labels:
+    {{- include "entitlement-store.labels" . | nindent 4 }}
 data:
   POSTGRES_DATABASE: {{ coalesce .Values.postgres.database .Values.global.opentdf.common.postgres.database | quote }}
   POSTGRES_HOST: {{ coalesce .Values.postgres.host .Values.global.opentdf.common.postgres.host | quote }}

--- a/charts/entitlements/templates/configmap.yaml
+++ b/charts/entitlements/templates/configmap.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "entitlements.name" . }}-cm
+  labels:
+    {{- include "entitlements.labels" . | nindent 4 }}
 data:
   # TODO /auth and /token are well-known and can be hardcoded
   # we do not need two config properties for this - just one.

--- a/charts/entity-resolution/templates/_helpers.tpl
+++ b/charts/entity-resolution/templates/_helpers.tpl
@@ -36,3 +36,35 @@ Create OIDC Internal Url from a common value
 {{- define "entity-resolution.keycloakUrl" }}
 {{- coalesce .Values.config.keycloak.url .Values.global.opentdf.common.oidcInternalBaseUrl }}
 {{- end }}
+
+
+{{/*
+Common labels
+*/}}
+{{- define "entity-resolution.labels" -}}
+helm.sh/chart: {{ include "entity-resolution.chart" . }}
+{{ include "entity-resolution.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "entity-resolution.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "entity-resolution.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "entity-resolution.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "entity-resolution.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/entity-resolution/templates/configmap.yaml
+++ b/charts/entity-resolution/templates/configmap.yaml
@@ -3,10 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "entity-resolution.fullname" . }}-cm
   labels:
-    app: {{ .Chart.Name | quote }}
-    chart: {{ include "entity-resolution.chart" . | quote }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "entity-resolution.labels" . | nindent 4 }}
 data:
   listenPort: {{ .Values.config.listenPort | quote }}
   externalHost: {{ .Values.config.externalHost | quote }}

--- a/charts/entity-resolution/templates/deployment.yaml
+++ b/charts/entity-resolution/templates/deployment.yaml
@@ -5,24 +5,20 @@ metadata:
   annotations:
     proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
   labels:
-    app: {{ .Chart.Name | quote }}
-    chart: {{ include "entity-resolution.chart" . | quote }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "entity-resolution.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ .Chart.Name | quote }}
-      release: {{ .Release.Name }}
+      {{- include "entity-resolution.selectorLabels" . | nindent 6 }}
   strategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-        app: {{ .Chart.Name | quote }}
-        release: {{ .Release.Name }}
+        {{- include "entity-resolution.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "entity-resolution.serviceAccountName" . }}
       containers:
       - name: {{ include "entity-resolution.fullname" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/entity-resolution/templates/secret.yaml
+++ b/charts/entity-resolution/templates/secret.yaml
@@ -4,10 +4,7 @@ kind: Secret
 metadata:
   name: {{ include "entity-resolution.fullname" . }}-keycloak-client-secret
   labels:
-    app: {{ .Chart.Name | quote }}
-    chart: {{ include "entity-resolution.chart" . | quote }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "entity-resolution.labels" . | nindent 4 }}
 type: Opaque
 data:
   keycloakClientSecret: {{ .Values.secret.keycloak.clientSecret | b64enc }}
@@ -18,7 +15,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "entity-resolution.fullname" . }}-pull-secret
+  labels:
+    {{- include "entity-resolution.labels" . | nindent 4 }}
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ include "imagePullSecret" . }}
+  .dockerconfigjson: {{ include "entity-resolution.imagePullSecret" . }}
 {{- end }}

--- a/charts/entity-resolution/templates/service.yaml
+++ b/charts/entity-resolution/templates/service.yaml
@@ -3,10 +3,7 @@ kind: Service
 metadata:
   name: {{ include "entity-resolution.fullname" . }}
   labels:
-    app: {{ .Chart.Name | quote }}
-    chart: {{ include "entity-resolution.chart" . | quote }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "entity-resolution.labels" . | nindent 4 }}
 spec:
   ports:
   - port: {{ .Values.config.listenPort }}

--- a/charts/entity-resolution/templates/serviceaccount.yaml
+++ b/charts/entity-resolution/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "entity-resolution.serviceAccountName" . }}
+  labels:
+    {{- include "entity-resolution.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/entity-resolution/values.yaml
+++ b/charts/entity-resolution/values.yaml
@@ -22,6 +22,15 @@ image:
 # Overrides global.opentdf.common.imagePullSecrets
 imagePullSecrets:
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 createKeycloakClientSecret: true
 secret:
   keycloak:

--- a/charts/kas/templates/configmap.yaml
+++ b/charts/kas/templates/configmap.yaml
@@ -3,10 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "kas.name" . }}-cm
   labels:
-    app.kubernetes.io/name: {{ include "kas.name" . }}-cm
-    helm.sh/chart: {{ include "kas.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "kas.labels" . | nindent 4 }}
     app.kubernetes.io/part-of: kas
 data:
   {{- with (coalesce .Values.endpoints.attrHost .Values.endpoints.easHost) }}

--- a/charts/kas/templates/secrets.yaml
+++ b/charts/kas/templates/secrets.yaml
@@ -4,10 +4,7 @@ kind: Secret
 metadata:
   name: {{ (include "kas.secretName" . ) }}
   labels:
-    app.kubernetes.io/name: {{ (include "kas.secretName" . ) }}
-    helm.sh/chart: {{ include "kas.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "kas.labels" . | nindent 4 }}
     app.kubernetes.io/part-of: kas  
 type: Opaque
 data:

--- a/charts/keycloak-bootstrap/templates/_helpers.tpl
+++ b/charts/keycloak-bootstrap/templates/_helpers.tpl
@@ -1,4 +1,4 @@
-{{- define "imagePullSecret" }}
+{{- define "entity-resolution.imagePullSecret" }}
 {{- with .Values.global.imageCredentials }}
 {{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
 {{- end }}
@@ -35,6 +35,27 @@ Create chart name and version as used by the chart label.
 {{- define "keycloak-bootstrap.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+
+{{/*
+Common labels
+*/}}
+{{- define "keycloak-bootstrap.labels" -}}
+helm.sh/chart: {{ include "keycloak-bootstrap.chart" . }}
+{{ include "keycloak-bootstrap.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "keycloak-bootstrap.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "keycloak-bootstrap.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
 
 
 {{/*

--- a/charts/keycloak-bootstrap/templates/bootstrap-configmap.yaml
+++ b/charts/keycloak-bootstrap/templates/bootstrap-configmap.yaml
@@ -3,9 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "keycloak-bootstrap.fullname" . }}-cm
   labels:
-    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
-    release: "{{ $.Release.Name }}"
-    heritage: "{{ $.Release.Service }}"
+    {{- include "keycloak-bootstrap.labels" . | nindent 4 }}
 data:
   config.yaml: |-
 {{ toYaml .Values.keycloak.customConfig | indent 4 }}

--- a/charts/keycloak-bootstrap/templates/keycloak-bootstrap-job.yaml
+++ b/charts/keycloak-bootstrap/templates/keycloak-bootstrap-job.yaml
@@ -3,10 +3,7 @@ kind: Job
 metadata:
   name: {{ include "keycloak-bootstrap.fullname" . }}
   labels:
-    app: {{ .Chart.Name | quote }}
-    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
-    release: "{{ $.Release.Name }}"
-    heritage: "{{ $.Release.Service }}"
+    {{- include "keycloak-bootstrap.labels" . | nindent 4 }}
 spec:
   template:
     spec:

--- a/charts/storage/templates/configmap.yaml
+++ b/charts/storage/templates/configmap.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "storage.name" . }}-cm
+  labels:
+    {{- include "storage.labels" . | nindent 4 }}
 data:
   AWS_DEFAULT_REGION: {{ .Values.s3BucketRegion | quote }}
   BUCKET: {{ .Values.s3Bucket | quote }}

--- a/common.Tiltfile
+++ b/common.Tiltfile
@@ -4,7 +4,7 @@
 # helm remote usage https://github.com/tilt-dev/tilt-extensions/tree/master/helm_remote#additional-parameters
 
 load("ext://helm_remote", "helm_remote")
-load("ext://helm_resource", "helm_resource", "helm_repo")
+load("ext://helm_resource", "helm_resource")
 load("ext://min_tilt_version", "min_tilt_version")
 
 min_tilt_version("0.30")


### PR DESCRIPTION
- Updates all the labels to include the current labels macro. Notably, replace things like `heritage` with the newer, well known names. See guidelines here: https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md#names-and-labels
- Adds missing labels (mostly to configMaps. Do those need them?)
- Adds a coupld of missing serviceAccount configurations
- Prefixes an unprefixed template in entity-resolution (imagePullSecret)

changes: _rev_

### Proposed Changes
_Please use the Jira Key or NOREF followd by the changes_

- Issue #5432
  - Some change
  - Another change

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
