### PR TITLE
🐛 Fix extra value that was misnamed

### DIFF
--- a/charts/kas/templates/_helpers.tpl
+++ b/charts/kas/templates/_helpers.tpl
@@ -79,7 +79,7 @@ Create oidc endpoint from a common value
 {{- end }}
 
 {{- define "kas.secretFromString" -}}
-{{- if and (not .root.Values.externalEnvSecretName) .value }}
+{{- if and (not .root.Values.externalSecretName) .value }}
 {{- b64enc .value }}
 {{- else }}
 {{- "" }}

--- a/charts/kas/templates/secrets.yaml
+++ b/charts/kas/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.externalEnvSecretName }}
+{{- if not .Values.externalSecretName }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/kas/values.yaml
+++ b/charts/kas/values.yaml
@@ -70,7 +70,7 @@ securityContext: {}
 certFileSecretName: null
 
 # The name of a secret containing required config values (see envConfig below); overrides envConfig
-externalEnvSecretName:
+externalSecretName:
 
 # Environment configuration values for keys and certs used by the key server.  If externalSecretName is defined these are ignored.
 envConfig:


### PR DESCRIPTION
- it looks like `externalSecretName` and `externalEnvSecretName` were intended to be the same value but somehow split
- This fix consolidates on the shorter name.
- This is distinct from all other charts which use either secretRef or a generic ref to allow bringing env data from configs or secrets

changes: _rev_

### Proposed Changes
_Please use the Jira Key or NOREF followd by the changes_

- Issue #5432
  - Some change
  - Another change

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
