### PR TITLE
remove buggy semver checking action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,13 +17,6 @@ jobs:
       contents: read
     timeout-minutes: 10
     steps:
-      # Quick check to ensure the release we have is tagged with strict semver
-      # https://jubianchi.github.io/semver-check/#/
-      # e.g. no leading v.
-      # If this fails, you need to re-`git tag` your release commit with a valid semver tag
-      - uses: rubenesp87/semver-validation-action@0.0.6
-        with:
-          version: ${{ github.event.release.tag_name }}
       - uses: actions/checkout@v3
       - uses: yokawasa/action-setup-kube-tools@v0.8.0
         with:


### PR DESCRIPTION
the library is buggy. 1.1.0-rc.11 was invalid even though it shouldnt have been: https://github.com/opentdf/backend/actions/runs/2966159919

we are removing for now but will add a better semver check in the future


### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
