### PR TITLE
remove containers with their own tagging policy

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -21,9 +21,6 @@ jobs:
           - keycloak-bootstrap 
           - entitlement-pdp
           - entity-resolution
-          - python-base
-          - entitlement-pdp/entitlements-policybundle
-          - keycloak
           - claims
     steps:
       -


### PR DESCRIPTION
removed the keycloak and python base containers as they have their own ptagging policy.

Removed policybundle for the entitlement pdp because there's no dockerfile there. let's look into this for the nex release. 

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
