### PR TITLE
🐛 Allow docker containers on host to resolve

### DIFF
--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -64,6 +64,7 @@ attributes:
       localhost: &pathsAttributes
         "/api/attributes(/|$)(.*)":
           pathType: Prefix
+      host.docker.internal: *pathsAttributes
       opentdf.local: *pathsAttributes
 entitlement-pdp:
   fullnameOverride: entitlement-pdp
@@ -94,6 +95,7 @@ entitlements:
       localhost: &pathsEntitlements
         "/api/entitlements(/|$)(.*)":
           pathType: Prefix
+      host.docker.internal: *pathsEntitlements
       opentdf.local: *pathsEntitlements
 entity-resolution:
   fullnameOverride: entity-resolution
@@ -120,6 +122,7 @@ kas:
       localhost: &pathsKas
         "/api/kas(/|$)(.*)":
           pathType: Prefix
+      host.docker.internal: *pathsKas
       opentdf.local: *pathsKas
   logLevel: DEBUG
   pdp:
@@ -175,6 +178,8 @@ keycloak:
         paths: &paths
           - path: /auth(/|$)(.*)
             pathType: Prefix
+      - host: host.docker.internal
+        paths: *paths
       - host: opentdf.local
         paths: *paths
     tls: []

--- a/tests/integration/backend-pki-values.yaml
+++ b/tests/integration/backend-pki-values.yaml
@@ -9,6 +9,7 @@ kas:
         "/api/kas(/|$)(.*)":
           pathType: Prefix
       host.docker.internal: *paths
+      opentdf.local: *paths
 
 keycloak:
   fullnameOverride: keycloak


### PR DESCRIPTION
- This lets a user running a standard docker container in the host OS to easily connect to a test backend api via the docker internal network

changes: _rev_

### Proposed Changes
_Please use the Jira Key or NOREF followd by the changes_

- Issue #5432
  - Some change
  - Another change

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
