### PR TITLE
CVE-2022-40674 expat=2.4.9-r0

### DIFF
--- a/containers/attributes/Dockerfile
+++ b/containers/attributes/Dockerfile
@@ -32,7 +32,8 @@ RUN diff <(python3 -m attributes.main) attributes/openapi.json
 # stage - production server
 FROM python:${PY_VERSION}-alpine${ALPINE_VERSION} AS production
 ARG PY_VERSION
-
+# CVE-2022-40674 - updating here until alpine does a relase with the fix - this can be removed once released
+RUN apk info expat && apk update expat=2.4.9-r0 && apk info expat
 WORKDIR /app
 COPY --from=build --chown=root:root /build/ .
 # NOTE - the python version needs to be specified in the following COPY command:

--- a/containers/entitlement-pdp/Dockerfile
+++ b/containers/entitlement-pdp/Dockerfile
@@ -60,7 +60,8 @@ RUN policy build entitlement-policy -t local:$(cat <VERSION) \
 
 # Create the minimal runtime image
 FROM golang:1.19-alpine AS emptyfinal
-
+# CVE-2022-40674 - updating here until alpine does a relase with the fix - this can be removed once released
+RUN apk info expat && apk update expat=2.4.9-r0 && apk info expat
 ENV HOME=/opt/entitlement-pdp
 ENV CACHEDIR=$HOME/policycache/bundles/entitlement-policy
 

--- a/containers/entitlement_store/Dockerfile
+++ b/containers/entitlement_store/Dockerfile
@@ -31,7 +31,8 @@ RUN diff <(python3 -m entitlement_store.main) entitlement_store/openapi.json
 # stage - production server
 FROM python:${PY_VERSION}-alpine${ALPINE_VERSION} AS production
 ARG PY_VERSION
-
+# CVE-2022-40674 - updating here until alpine does a relase with the fix - this can be removed once released
+RUN apk info expat && apk update expat=2.4.9-r0 && apk info expat
 WORKDIR /app
 COPY --from=build --chown=root:root /build/ .
 # NOTE - the python version needs to be specified in the following COPY command:

--- a/containers/entitlements/Dockerfile
+++ b/containers/entitlements/Dockerfile
@@ -32,7 +32,8 @@ RUN diff <(python3 -m entitlements.main) entitlements/openapi.json
 # stage - production server
 FROM python:${PY_VERSION}-alpine${ALPINE_VERSION} AS production
 ARG PY_VERSION
-
+# CVE-2022-40674 - updating here until alpine does a relase with the fix - this can be removed once released
+RUN apk info expat && apk update expat=2.4.9-r0 && apk info expat
 WORKDIR /app
 COPY --from=build --chown=root:root /build/ .
 # NOTE - the python version needs to be specified in the following COPY command:

--- a/containers/entity-resolution/Dockerfile
+++ b/containers/entity-resolution/Dockerfile
@@ -48,7 +48,8 @@ RUN go build -o /dist/entity-resolution-service
 
 # Create the minimal runtime image
 FROM golang:1.19-alpine AS emptyfinal
-
+# CVE-2022-40674 - updating here until alpine does a relase with the fix - this can be removed once released
+RUN apk info expat && apk update expat=2.4.9-r0 && apk info expat
 COPY --chown=0:0 --from=builder /dist/entity-resolution-service /entity-resolution-service
 
 ENTRYPOINT ["/entity-resolution-service"]

--- a/containers/kas/Dockerfile
+++ b/containers/kas/Dockerfile
@@ -40,7 +40,8 @@ RUN python3 -m compileall .
 FROM python:${PY_VERSION}-slim AS production
 
 ARG PY_VERSION
-
+# CVE-2022-40674 - updating here until alpine does a relase with the fix - this can be removed once released
+RUN apk info expat && apk update expat=2.4.9-r0 && apk info expat
 WORKDIR /kas_app
 ENV KAS_UID ${KAS_UID:-909}
 

--- a/containers/python_base/Dockerfile
+++ b/containers/python_base/Dockerfile
@@ -3,6 +3,8 @@ ARG ALPINE_VERSION=3.16
 
 # stage - build
 FROM python:${PY_VERSION}-alpine${ALPINE_VERSION} AS build
+# CVE-2022-40674 - updating here until alpine does a relase with the fix - this can be removed once released
+RUN apk info expat && apk update expat=2.4.9-r0 && apk info expat
 # Install apk dependencies
 RUN apk add --no-cache --upgrade \
     gcc \


### PR DESCRIPTION
changes: _rev_

### Proposed Changes
CVE-2022-40674
- updates base alpine images to use the fixed version of expat library

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
