### PR TITLE
[WIP] PLAT-2174; change sha to use tagged commit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
       - run: |-
           echo "::set-output name=CORE::${RELEASE_TAG%%-*}"
           echo "::set-output name=FULL::${RELEASE_TAG}"
-          echo "::set-output name=SHA::sha-$(git rev-parse --short HEAD)"
+          echo "::set-output name=SHA::sha-$(git rev-list -n 1 --abbrev-commit ${RELEASE_TAG})"
         id: info
 
   docker:


### PR DESCRIPTION


### Proposed Changes
[backend/release.yaml at main · opentdf/backend](https://github.com/opentdf/backend/blob/main/.github/workflows/release.yaml#L30) this line takes the sha from HEAD: `git rev-parse --short HEAD`

we need to `# GITHUB_SHA/REF will be set to the SHA/REF of the last commit in the tagged release` , as it states on line 3 of that file. to get the commit from the tagged release, we can do:

git rev-list -n 1 --abbrev-commit ${RELEASE_TAG}

[PLAT-2174](https://virtru.atlassian.net/browse/PLAT-2174)

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
I will test by trying to publish a release after this is merged. 