### PR TITLE
Clean up KAS key handling a bit

### DIFF
--- a/charts/backend/README.md
+++ b/charts/backend/README.md
@@ -2,17 +2,32 @@
 ## Deploy Chart
 
 1. Create Cluster: `ctlptl create cluster kind --registry=ctlptl-registry --name kind-opentdf`
-2. Update Dependencies: `helm dependency update`
-3. Run certs.env `source ../../certs/.env`
-4. Install Chart: 
+1. Update Dependencies: `helm dependency update`
+1. Install Chart (will generate non-production KAS keys if none provided): 
+
+```sh
+helm upgrade --install backend -f testing/deployment.yaml .
 ```
-helm upgrade --install backend -f values.yaml -f testing/deployment.yaml \
---set kas.envConfig.attrAuthorityCert=$ATTR_AUTHORITY_CERTIFICATE \
---set kas.envConfig.ecCert=$KAS_EC_SECP256R1_CERTIFICATE \
---set kas.envConfig.cert=$KAS_CERTIFICATE \
---set kas.envConfig.ecPrivKey=$KAS_EC_SECP256R1_PRIVATE_KEY \
---set kas.envConfig.privKey=$KAS_PRIVATE_KEY .
+
+If you wish to provide and manage your own KAS keys (recommended), you may do so by either:
+
+1. Creating/managing your own named K8S Secret in the chart namespace in the form described by [](./templates/secrets.yaml), and setting `kas.externalEnvSecretName` accordingly:
+``` sh
+helm upgrade --install backend -f testing/deployment.yaml \
+  --set kas.externalEnvSecretName=<Secret-with-rsa-and-ec-keypairs> .
 ```
+
+1. Supplying each private/public key as a values override, e.g:
+
+``` sh
+helm upgrade --install backend -f testing/deployment.yaml \
+  --set kas.envConfig.attrAuthorityCert=$ATTR_AUTHORITY_CERTIFICATE \
+  --set kas.envConfig.ecCert=$KAS_EC_SECP256R1_CERTIFICATE \
+  --set kas.envConfig.cert=$KAS_CERTIFICATE \
+  --set kas.envConfig.ecPrivKey=$KAS_EC_SECP256R1_PRIVATE_KEY \
+  --set kas.envConfig.privKey=$KAS_PRIVATE_KEY .
+```
+
 
 ## Cluster Status 
   To check to see if your cluster is running, enter the following command:

--- a/charts/kas/README.md
+++ b/charts/kas/README.md
@@ -6,10 +6,7 @@ These keys are important, as they are the "keys to the kingdom", so to speak - p
 
 Also, if the keys change, TDF files created with the previous set will no longer be decryptable.
 
-
 Therefore, it is strongly recommended that these keys be generated and managed properly in a production environment.
-
-
 
 1. Install Chart (will generate throwaway non-production KAS keys if none provided at install time, not recommended or supported for production): 
 

--- a/charts/kas/README.md
+++ b/charts/kas/README.md
@@ -1,0 +1,36 @@
+# KAS
+
+KAS needs at least 4 keys (2 pairs, one RSA and one EC pair) to run.
+
+These keys are important, as they are the "keys to the kingdom", so to speak - possessing them might allow data access by unauthorized parties.
+
+Also, if the keys change, TDF files created with the previous set will no longer be decryptable.
+
+
+Therefore, it is strongly recommended that these keys be generated and managed properly in a production environment.
+
+
+
+1. Install Chart (will generate throwaway non-production KAS keys if none provided at install time, not recommended or supported for production): 
+
+```sh
+helm upgrade --install kas .
+```
+
+If you wish to provide and manage your own KAS keys (recommended), you may do so by either:
+
+1. Creating/managing your own named K8S Secret in the chart namespace in the form described by [](./templates/secrets.yaml), and setting `kas.externalEnvSecretName` accordingly:
+``` sh
+helm upgrade --install kas --set externalEnvSecretName=<Secret-with-rsa-and-ec-keypairs> .
+```
+
+1. Supplying each private/public key as a values override, e.g:
+
+``` sh
+helm upgrade --install kas \
+  --set envConfig.attrAuthorityCert=$ATTR_AUTHORITY_CERTIFICATE \
+  --set envConfig.ecCert=$KAS_EC_SECP256R1_CERTIFICATE \
+  --set envConfig.cert=$KAS_CERTIFICATE \
+  --set envConfig.ecPrivKey=$KAS_EC_SECP256R1_PRIVATE_KEY \
+  --set envConfig.privKey=$KAS_PRIVATE_KEY .
+```

--- a/charts/kas/templates/_helpers.tpl
+++ b/charts/kas/templates/_helpers.tpl
@@ -77,31 +77,3 @@ Create oidc endpoint from a common value
 {{- printf "%s-secrets" ( include "kas.name" . ) }}
 {{- end }}
 {{- end }}
-
-{{- define "kas.secretFromString" -}}
-{{- if and (not .root.Values.externalEnvSecretName) .value }}
-{{- b64enc .value }}
-{{- else }}
-{{- "" }}
-{{- end }}
-{{- end }}
-
-{{- define "kas.ATTR_AUTHORITY_CERTIFICATE" }}
-{{- dict "root" . "value" .Values.envConfig.attrAuthorityCert | include "kas.secretFromString" }}
-{{- end }}
-
-{{- define "kas.KAS_EC_SECP256R1_CERTIFICATE" }}
-{{- dict "root" . "value" .Values.envConfig.ecCert | include "kas.secretFromString" }}
-{{- end }}
-
-{{- define "kas.KAS_CERTIFICATE" }}
-{{- dict "root" . "value" .Values.envConfig.cert | include "kas.secretFromString" }}
-{{- end }}
-
-{{- define "kas.KAS_EC_SECP256R1_PRIVATE_KEY" }}
-{{- dict "root" . "value" .Values.envConfig.ecPrivKey | include "kas.secretFromString" }}
-{{- end }}
-
-{{- define "kas.KAS_PRIVATE_KEY" }}
-{{- dict "root" . "value" .Values.envConfig.privKey | include "kas.secretFromString" }}
-{{- end }}

--- a/charts/kas/templates/deployment.yaml
+++ b/charts/kas/templates/deployment.yaml
@@ -35,11 +35,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - secretRef:
-                name: {{ include "kas.secretName" . }} 
-            {{- if .Values.extraEnvSecretName }}
-            - secretRef:
-                name: {{ .Values.extraEnvSecretName }} 
-            {{- end }}
+                name: {{ include "kas.secretName" . }}
             - configMapRef:
                 name: {{ include "kas.name" . }}-cm
           ports:

--- a/charts/kas/templates/secrets.yaml
+++ b/charts/kas/templates/secrets.yaml
@@ -18,7 +18,7 @@ metadata:
 type: Opaque
 data:
   ATTR_AUTHORITY_CERTIFICATE: |-
-        {{ .Values.envConfig.attrAuthorityCert }}
+        {{ .Values.envConfig.attrAuthorityCert | b64enc }}
   KAS_EC_SECP256R1_CERTIFICATE: |
         {{ coalesce .Values.envConfig.ecCert $kasEC.Cert | b64enc }}
   KAS_CERTIFICATE: |

--- a/charts/kas/templates/secrets.yaml
+++ b/charts/kas/templates/secrets.yaml
@@ -1,3 +1,12 @@
+{{- $cn := .Release.Name }}
+{{- $kasRSA := genSelfSignedCertWithKey $cn (list) (list) 365 (genPrivateKey "rsa") }}
+# Note that the Sprig template uses the P-256 EC curve - if this is something that matters to you, you shouldn't be using template-generated toy certs to begin with, and should supply your own.
+{{- $kasEC := genSelfSignedCertWithKey $cn (list) (list) 365 (genPrivateKey "ecdsa") }}
+
+
+# 1. If you gave us preexisting key pairs via a named Secret resource that already exists, we use that
+# 2. If you gave us preexisting key pairs via named .Values.envConfig.xxx properties, we use that.
+# 3. If you gave us none of the above, we use Sprig template funcs to generate throwaway key pairs and use those.
 {{- if not .Values.externalEnvSecretName }}
 apiVersion: v1
 kind: Secret
@@ -9,13 +18,13 @@ metadata:
 type: Opaque
 data:
   ATTR_AUTHORITY_CERTIFICATE: |-
-        {{ ( include "kas.ATTR_AUTHORITY_CERTIFICATE" . ) }}
-  KAS_EC_SECP256R1_CERTIFICATE: |-
-        {{ ( include "kas.KAS_EC_SECP256R1_CERTIFICATE" . ) }}
-  KAS_CERTIFICATE: |-
-        {{ ( include "kas.KAS_CERTIFICATE" . ) }}
-  KAS_EC_SECP256R1_PRIVATE_KEY: |-
-        {{ ( include "kas.KAS_EC_SECP256R1_PRIVATE_KEY" . ) }}
-  KAS_PRIVATE_KEY: |-
-        {{ ( include "kas.KAS_PRIVATE_KEY" . ) }}
-{{- end }}  
+        {{ .Values.envConfig.attrAuthorityCert }}
+  KAS_EC_SECP256R1_CERTIFICATE: |
+        {{ coalesce .Values.envConfig.ecCert $kasEC.Cert | b64enc }}
+  KAS_CERTIFICATE: |
+        {{ coalesce .Values.envConfig.cert $kasRSA.Cert | b64enc }}
+  KAS_EC_SECP256R1_PRIVATE_KEY: |
+        {{ coalesce .Values.envConfig.ecPrivKey $kasEC.Key | b64enc }}
+  KAS_PRIVATE_KEY: |
+        {{ coalesce .Values.envConfig.privKey $kasRSA.Key | b64enc }}
+{{- end }}

--- a/charts/kas/templates/secrets.yaml
+++ b/charts/kas/templates/secrets.yaml
@@ -17,8 +17,11 @@ metadata:
     app.kubernetes.io/part-of: kas  
 type: Opaque
 data:
+
+  {{- if .Values.envConfig.attrAuthorityCert }}
   ATTR_AUTHORITY_CERTIFICATE: |-
         {{ .Values.envConfig.attrAuthorityCert | b64enc }}
+  {{- end }}
   KAS_EC_SECP256R1_CERTIFICATE: |
         {{ coalesce .Values.envConfig.ecCert $kasEC.Cert | b64enc }}
   KAS_CERTIFICATE: |


### PR DESCRIPTION
-------

### Proposed Changes
- PLAT-2063
  - Remove dependence on out of band cert gen script for deploying KAS.
     1 . If you gave us preexisting key pairs via a named Secret resource that already exists, we use that (**existing behavior**)
     2. If you gave us preexisting key pairs via named .`Values.envConfig.xxx` properties, we use that (**existing behavior**)
     3. If you gave us none of the above, we use Sprig template funcs to generate throwaway RSA/EC key pairs and use those (**_added behavior_**), so KAS can start without crashing out of the box.

 

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions