### PR TITLE
📌 Pins keycloak in umbrella chart

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -500,7 +500,6 @@ jobs:
           tags: |
             type=ref,event=branch
             type=sha
-            type-raw,value=${{ needs.config.outputs.KEYCLOAK_OTDF_VERSION }}
       - name: Set up QEMU (required for crossbuild)
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,7 @@ jobs:
     outputs:
       CORE_VERSION: "${{ steps.info.outputs.CORE }}"
       FULL_VERSION: "${{ steps.info.outputs.FULL }}"
+      KEYCLOAK_OTDF_VERSION: "${{ steps.keycloak-otdf-version.outputs.KEYCLOAK_OTDF_VERSION }}-${{ steps.info.outputs.FULL }}"
       SHA_TAG: "${{ steps.info.outputs.SHA }}"
     timeout-minutes: 5
     steps:
@@ -29,8 +30,13 @@ jobs:
           echo "FULL=${RELEASE_TAG}" >> $GITHUB_OUTPUT
           echo "SHA=sha-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
         id: info
+      - name: Keycloak application version
+        run: |
+          KEYCLOAK_OTDF_VERSION="$(cut -d- -f1 <containers/keycloak-protocol-mapper/VERSION)"
+          echo "KEYCLOAK_OTDF_VERSION=$KEYCLOAK_OTDF_VERSION" >> $GITHUB_OUTPUT
+        id: keycloak-otdf-version
 
-  docker:
+  tag-microservice-containers:
     runs-on: ubuntu-latest
     needs:
       - version
@@ -67,6 +73,35 @@ jobs:
           docker buildx imagetools create
           "ghcr.io/opentdf/${{ matrix.repo }}:${SHA_TAG}"
           --tag "ghcr.io/opentdf/${{ matrix.repo }}:${FULL_VERSION}"
+
+  tag-custom-keycloak:
+    runs-on: ubuntu-latest
+    needs:
+      - version
+    permissions:
+      packages: write
+      contents: read
+    env:
+      FULL_VERSION: "${{ needs.version.outputs.FULL_VERSION }}"
+      SHA_TAG: "${{ needs.version.outputs.SHA_TAG }}"
+      KEYCLOAK_OTDF_VERSION: "${{ needs.version.outputs.KEYCLOAK_OTDF_VERSION }}"
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Tag existing images
+        run: >-
+          docker buildx imagetools create
+          "ghcr.io/opentdf/keycloak:${SHA_TAG}"
+          --tag "ghcr.io/opentdf/keycloak:${KEYCLOAK_OTDF_VERSION}"
 
   policybundle:
     needs:
@@ -112,7 +147,8 @@ jobs:
       packages: write
       contents: read
     needs:
-      - docker
+      - tag-custom-keycloak
+      - tag-microservice-containers
       - policybundle
       - version
     env:
@@ -157,7 +193,7 @@ jobs:
   signing-artifacts:
     needs:
       - version
-      - docker
+      - tag-microservice-containers
     permissions:
       packages: write
       contents: read

--- a/containers/python_base/scripts/update-charts
+++ b/containers/python_base/scripts/update-charts
@@ -96,6 +96,8 @@ update-umbrella-deps() {
 yq --version || e "Missing binary: yq"
 cd "${PROJECT_ROOT}/charts" || e "Unable to find charts folder in [${PROJECT_ROOT}]"
 short_ver=sha-$(git rev-parse --short HEAD)
+repo_uri=oci://ghcr.io/${GITHUB_REPOSITORY_OWNER:-opentdf}/charts
+keycloak_version=${appVersion-for keycloak-protocol-mapper}
 
 case "$1" in
   help | --help | -h)
@@ -116,7 +118,11 @@ case "$1" in
         set-version "$x"
       fi
     done
-    update-umbrella-deps
+    if [[ $2 ]]; then
+      update-umbrella-deps "${repo_uri}" "${keycloak_version}-$2"
+    else
+      update-umbrella-deps "${repo_uri}" "${keycloak_version}"
+    fi
     ;;
   local)
     monolog DEBUG "Reset to local development"
@@ -126,7 +132,7 @@ case "$1" in
         set-version "$x"
       fi
     done
-    update-umbrella-deps "file://.."
+    update-umbrella-deps "file://.." main
     helm dependency update backend
     ;;
   *)
@@ -137,6 +143,6 @@ case "$1" in
         set-version "$x" "0.0.0-$short_ver"
       fi
     done
-    update-umbrella-deps
+    update-umbrella-deps "${repo_uri}" "$short_ver"
     ;;
 esac

--- a/containers/python_base/scripts/update-charts
+++ b/containers/python_base/scripts/update-charts
@@ -78,7 +78,7 @@ set-version() {
 
 # Updates local deps from backend chart on others
 update-umbrella-deps() {
-  repo="${1:-oci://ghcr.io/${GITHUB_REPOSITORY_OWNER:-opentdf}/charts}"
+  repo="$1"
   sub_charts=("attributes" "entitlement-pdp" "entitlement-store" "entitlements" "entity-resolution" "kas" "keycloak-bootstrap")
   for sub_chart in "${sub_charts[@]}"; do
     cv="$(chartVersion-for "${sub_chart}")"
@@ -91,13 +91,14 @@ update-umbrella-deps() {
     fi
     depname="${sub_chart}" repo="${subrepo}" yq '(.dependencies[] | select(.name == env(depname)) | .repository ) = strenv(repo)' -i "$(chart-for backend)"
   done
+  tag="$2" yq '.keycloak.image.tag = strenv(tag)' -i "${PROJECT_ROOT}/charts/backend/values.yaml"
 }
 
 yq --version || e "Missing binary: yq"
 cd "${PROJECT_ROOT}/charts" || e "Unable to find charts folder in [${PROJECT_ROOT}]"
 short_ver=sha-$(git rev-parse --short HEAD)
 repo_uri=oci://ghcr.io/${GITHUB_REPOSITORY_OWNER:-opentdf}/charts
-keycloak_version=${appVersion-for keycloak-protocol-mapper}
+keycloak_version=$(appVersion-for keycloak-protocol-mapper)
 
 case "$1" in
   help | --help | -h)


### PR DESCRIPTION
### Proposed Changes
_Please use the Jira Key or NOREF followd by the changes_

- Fixes issue where we are tracking floating 'main' tag for our custom keycloak image in the 'backend' umbrella chart
- Update tagging of the custom image to only tag with the app version (and some metadata) on release
- This should fix the issue where changes to the Keycloak image will show up in clusters targeting older, release managed configurations

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
