### PR TITLE
🐛 adds policytool pinning to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,6 +114,7 @@ jobs:
     env:
       BUNDLETAG: ghcr.io/opentdf/entitlement-pdp/entitlements-policybundle
       FULL_VERSION: "${{ needs.version.outputs.FULL_VERSION }}"
+      POLICYTOOL_VERSION: v0.1.42
       SHA_TAG: "${{ needs.version.outputs.SHA_TAG }}"
     steps:
       - uses: actions/checkout@v3
@@ -134,7 +135,7 @@ jobs:
           go-version: ">=1.18.0"
       - name: Build policy bundle
         run: |
-          go install github.com/opcr-io/policy/cmd/policy@latest
+          go install github.com/opcr-io/policy/cmd/policy@${{ env.POLICYTOOL_VERSION }}
           cd containers/entitlement-pdp/entitlement-policy
           policy login --server=ghcr.io -u ${{ github.repository_owner }} -p ${{ secrets.GITHUB_TOKEN }}
           policy pull "${BUNDLETAG}:${SHA_TAG}"


### PR DESCRIPTION
- This was missed in https://github.com/opentdf/backend/pull/356
- See linked upstream (unfixed) bug: https://github.com/opcr-io/policy/issues/98

changes: _rev_

### Proposed Changes
_Please use the Jira Key or NOREF followd by the changes_

- Release workflow is blocked on policy tool installation bug, https://github.com/opcr-io/policy/issues/98
- This pins it as @bleggett did earlier in #356 

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
