### PR TITLE
PLAT-2217 Rename KEYCLOAK_URL and USE_KEYCLOAK

### DIFF
--- a/charts/kas/templates/configmap.yaml
+++ b/charts/kas/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
   {{- end }}
   FLASK_DEBUG: {{ .Values.flaskDebug | quote }}
   GUNICORN_WORKERS: {{ .Values.gunicornWorkers | default 1 | quote }}
-  KEYCLOAK_HOST: {{ include "kas.oidcPubkeyEndpoint" . | quote }}
+  OIDC_SERVER_URL: {{ include "kas.oidcPubkeyEndpoint" . | quote }}
   LOGLEVEL: {{ .Values.logLevel | quote }}
   VERBOSE: {{ .Values.pdp.verbose | quote }}
   {{- with .Values.endpoints.statsdHost }}
@@ -21,4 +21,4 @@ data:
   JSON_LOGGER: {{ .Values.jsonLogger | default "true" | quote }}
   AUDIT_ENABLED: {{ .Values.global.opentdf.common.auditLogEnabled | quote  }}
 
-  USE_KEYCLOAK: "1"
+  USE_OIDC: "1"

--- a/containers/kas/kas_app/tdf3_kas_app/kas_app.py
+++ b/containers/kas/kas_app/tdf3_kas_app/kas_app.py
@@ -17,8 +17,8 @@ from .plugins import (
 logger = logging.getLogger(__name__)
 
 
-USE_KEYCLOAK = os.environ.get("USE_KEYCLOAK") == "1"
-KEYCLOAK_HOST = os.environ.get("KEYCLOAK_HOST") is not None
+USE_OIDC = os.environ.get("USE_OIDC") == "1"
+OIDC_SERVER_URL = os.environ.get("OIDC_SERVER_URL") is not None
 
 
 def configure_filters(kas):
@@ -35,7 +35,7 @@ def configure_filters(kas):
     filter_plugin = revocation_plugin.RevocationPlugin(allows=allows, blocks=blocks)
     kas.use_rewrap_plugin(filter_plugin)
     kas.use_upsert_plugin(filter_plugin)
-    if USE_KEYCLOAK:
+    if USE_OIDC:
         # filter_plugin = revocation_plugin.RevocationPluginV2(allows=allows, blocks=blocks)
         kas.use_rewrap_plugin_v2(filter_plugin)
         kas.use_upsert_plugin_v2(filter_plugin)
@@ -61,7 +61,7 @@ def app(name):
     The name parameter is the name of the execution root. Typically this will
     be __main__.
     """
-    global USE_KEYCLOAK
+    global USE_OIDC
     # Construct the KAS instance
     kas = Kas.get_instance()
     kas.set_root_name(name)
@@ -78,10 +78,10 @@ def app(name):
             logger.exception(e)
             logger.warning("Version not set")
 
-    if USE_KEYCLOAK and KEYCLOAK_HOST:
+    if USE_OIDC and OIDC_SERVER_URL:
         logger.info("Keycloak integration enabled.")
-    elif USE_KEYCLOAK or KEYCLOAK_HOST:
-        e_msg = "Either USE_KEYCLOAK or KEYCLOAK_HOST are not correctly defined - both are required."
+    elif USE_OIDC or OIDC_SERVER_URL:
+        e_msg = "Either USE_OIDC or OIDC_SERVER_URL are not correctly defined - both are required."
         logger.error(e_msg)
         raise Exception(e_msg)
     # Add Attribute fetch plugin

--- a/containers/kas/kas_core/tdf3_kas_core/keycloak.py
+++ b/containers/kas/kas_core/tdf3_kas_core/keycloak.py
@@ -16,9 +16,9 @@ logger = logging.getLogger(__name__)
 
 
 def _get_keycloak_host():
-    kc_host = os.environ.get("KEYCLOAK_HOST")
+    kc_host = os.environ.get("OIDC_SERVER_URL")
     if not kc_host:
-        raise AuthorizationError("KEYCLOAK_HOST not set! Can't fetch keys")
+        raise AuthorizationError("OIDC_SERVER_URL not set! Can't fetch keys")
 
     return kc_host
 

--- a/containers/kas/kas_core/tdf3_kas_core/keycloak_test.py
+++ b/containers/kas/kas_core/tdf3_kas_core/keycloak_test.py
@@ -101,8 +101,8 @@ def mocked_requests_get_fails(*args, **kwargs):
 def test_get_keycloak_public_key_fails_without_required_env(mock_get):
     """Tests that fetching KC pubkey, but without crucial
     env vars set, will raise."""
-    with pytest.raises(Exception, match=r"KEYCLOAK_HOST"):
-        del os.environ["KEYCLOAK_HOST"]
+    with pytest.raises(Exception, match=r"OIDC_SERVER_URL"):
+        del os.environ["OIDC_SERVER_URL"]
         pubkey = keycloak.get_keycloak_public_key("tdf")
     # Should bail before it makes a request if the env vars aren't set.
     assert mock_get.called == False
@@ -112,7 +112,7 @@ def test_get_keycloak_public_key_fails_without_required_env(mock_get):
 def test_get_keycloak_public_key_succeeds_with_required_env(mock_get):
     """Tests that fetching KC pubkey, but with crucial
     env vars set, will fetch pubkey."""
-    os.environ["KEYCLOAK_HOST"] = "https://mykc.com"
+    os.environ["OIDC_SERVER_URL"] = "https://mykc.com"
     pubkey = keycloak.get_keycloak_public_key("tdf")
     assert mock_get.called == True
     assert pubkey
@@ -129,7 +129,7 @@ def test_try_extract_realm_returns_realmkey(mock_get):
 def test_load_realm_key_prefers_cached_key(mock_get):
     key_master = FakeKeyMaster()
     realm = "tdf"
-    os.environ["KEYCLOAK_HOST"] = "https://mykc.com"
+    os.environ["OIDC_SERVER_URL"] = "https://mykc.com"
     realmKey = keycloak.load_realm_key(realm, key_master)
     assert mock_get.called == False
     assert realmKey
@@ -139,7 +139,7 @@ def test_load_realm_key_prefers_cached_key(mock_get):
 def test_load_realm_key_fetches_uncached_key(mock_get):
     key_master = FakeKeyMaster()
     realm = "someRealm"
-    os.environ["KEYCLOAK_HOST"] = "https://mykc.com"
+    os.environ["OIDC_SERVER_URL"] = "https://mykc.com"
     realmKey = keycloak.load_realm_key(realm, key_master)
     assert mock_get.called == True
     assert realmKey
@@ -150,7 +150,7 @@ def test_uncached_key_fetch_fails_returns_falsy_empty(mock_get):
     key_master = FakeKeyMaster()
     realm = "someRealm"
     realmKey = ""
-    os.environ["KEYCLOAK_HOST"] = "https://mykc.com"
+    os.environ["OIDC_SERVER_URL"] = "https://mykc.com"
     realmKey = keycloak.load_realm_key(realm, key_master)
     assert mock_get.called == True
     assert not realmKey

--- a/containers/kas/kas_core/tdf3_kas_core/services.py
+++ b/containers/kas/kas_core/tdf3_kas_core/services.py
@@ -74,7 +74,7 @@ logger = logging.getLogger(__name__)
 flags = {
     # TODO(PLAT-1212) Remove (set to False)
     "default_to_small_iv": os.environ.get("LEGACY_NANOTDF_IV") == "1",
-    "idp": os.environ.get("USE_KEYCLOAK") == "1",
+    "idp": os.environ.get("USE_OIDC") == "1",
 }
 
 

--- a/containers/kas/kas_core/tdf3_kas_core/services_test.py
+++ b/containers/kas/kas_core/tdf3_kas_core/services_test.py
@@ -197,7 +197,7 @@ def test_ping():
 )
 def test_rewrap_v2(entity_load_mock, tdf3_mock, nano_mock, jwt_mock, with_idp):
     """Test the rewrap_v2 service."""
-    os.environ["KEYCLOAK_HOST"] = "https://keycloak.dev"
+    os.environ["OIDC_SERVER_URL"] = "https://keycloak.dev"
     expected_uuid = "1111-2222-33333-44444-abddef-timestamp"
     expected_canonical = "This is a canonical string"
     attributes = [


### PR DESCRIPTION
changes: _rev_

### Proposed Changes

_Please use the Jira Key or NOREF followd by the changes_

- PLAT-2217
  - Rename KEYCLOAK_URL to OIDC_SERVER_URL
  - Rename USE_KEYCLOAK to USE_OIDC

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
