### PR TITLE
PLAT-2299 Add post logout redirect uris for all default bootstrap clients

### DIFF
--- a/containers/keycloak-bootstrap/keycloak_bootstrap.py
+++ b/containers/keycloak-bootstrap/keycloak_bootstrap.py
@@ -198,7 +198,10 @@ def createTestClientForX509Flow(keycloak_admin):
                 "protocol": "openid-connect",
                 "redirectUris": redirect_uris,
                 "webOrigins": ["+"],
-                "attributes": {"x509.subjectdn": "CN=(.*)(?:$)"},
+                "attributes": {
+                    "x509.subjectdn": "CN=(.*)(?:$)",
+                    "post.logout.redirect.uris": "+"
+                },
             },
             skip_exists=True,
         )
@@ -228,6 +231,7 @@ def createTestClientForClientCredentialsFlow(
             "attributes": {
                 "user.info.response.signature.alg": "RS256",
                 "pkce.code.challenge.method": "S256",
+                "post.logout.redirect.uris": "+",
             },  # Needed to make UserInfo return signed JWT
         },
         skip_exists=True,
@@ -308,7 +312,8 @@ def createPreloadedTDFClients(keycloak_admin, keycloak_auth_url, preloaded_clien
                     keycloak_auth_url + "admin/" + item["clientId"] + "/console"
                 ],
                 "attributes": {
-                    "user.info.response.signature.alg": "RS256"
+                    "user.info.response.signature.alg": "RS256",
+                    "post.logout.redirect.uris": "+",
                 },  # Needed to make UserInfo return signed JWT
             },
             skip_exists=True,
@@ -338,7 +343,8 @@ def createTestClientTDFAttributes(keycloak_admin):
             "redirectUris": redirect_uris,
             "webOrigins": ["+"],
             "attributes": {
-                "user.info.response.signature.alg": "RS256"
+                "user.info.response.signature.alg": "RS256",
+                "post.logout.redirect.uris": "+",
             },  # Needed to make UserInfo return signed JWT
         },
         skip_exists=True,
@@ -367,6 +373,7 @@ def createTestClientTDFEntitlements(keycloak_admin):
             "webOrigins": ["+"],
             "attributes": {
                 "user.info.response.signature.alg": "RS256"
+                "post.logout.redirect.uris": "+",
             },  # Needed to make UserInfo return signed JWT
         },
         skip_exists=True,
@@ -396,7 +403,8 @@ def createTestClientTDFEntityResolution(keycloak_admin):
             "redirectUris": redirect_uris,
             "webOrigins": ["+"],
             "attributes": {
-                "user.info.response.signature.alg": "RS256"
+                "user.info.response.signature.alg": "RS256",
+                "post.logout.redirect.uris": "+",
             },  # Needed to make UserInfo return signed JWT
         },
         skip_exists=True,
@@ -438,6 +446,7 @@ def createTestClientForAbacusWebAuth(keycloak_admin):
             "protocol": "openid-connect",
             "redirectUris": redirect_uris,
             "webOrigins": ["+"],
+            "attributes": {"post.logout.redirect.uris": "+"},
         },
         skip_exists=True,
     )
@@ -520,8 +529,9 @@ def createTestClientForExchangeFlow(keycloak_admin, keycloak_auth_url):
             "publicClient": "false",
             "redirectUris": redirect_uris,
             "attributes": {
-                "user.info.response.signature.alg": "RS256"
-            },  # Needed to make UserInfo return signed JWT
+                "user.info.response.signature.alg": "RS256", # Needed to make UserInfo return signed JWT
+                "post.logout.redirect.uris": "+",
+            },
         },
         skip_exists=True,
     )

--- a/containers/keycloak-bootstrap/keycloak_bootstrap.py
+++ b/containers/keycloak-bootstrap/keycloak_bootstrap.py
@@ -253,8 +253,9 @@ def createTestClientForBrowserAuthFlow(keycloak_admin):
             "redirectUris": redirect_uris,
             "webOrigins": ["+"],
             "attributes": {
-                "user.info.response.signature.alg": "RS256"
-            },  # Needed to make UserInfo return signed JWT
+                "user.info.response.signature.alg": "RS256", # Needed to make UserInfo return signed JWT
+                "post.logout.redirect.uris": "+",
+            },  
         },
         skip_exists=True,
     )
@@ -491,6 +492,7 @@ def createTestClientForDCRAuth(keycloak_admin):
             "protocol": "openid-connect",
             "redirectUris": redirect_uris,
             "webOrigins": ["+"],
+            "attributes": {"post.logout.redirect.uris": "+"},
         },
         skip_exists=True,
     )

--- a/containers/keycloak-bootstrap/keycloak_bootstrap.py
+++ b/containers/keycloak-bootstrap/keycloak_bootstrap.py
@@ -200,7 +200,7 @@ def createTestClientForX509Flow(keycloak_admin):
                 "webOrigins": ["+"],
                 "attributes": {
                     "x509.subjectdn": "CN=(.*)(?:$)",
-                    "post.logout.redirect.uris": "+"
+                    "post.logout.redirect.uris": "+",
                 },
             },
             skip_exists=True,
@@ -372,7 +372,7 @@ def createTestClientTDFEntitlements(keycloak_admin):
             "redirectUris": redirect_uris,
             "webOrigins": ["+"],
             "attributes": {
-                "user.info.response.signature.alg": "RS256"
+                "user.info.response.signature.alg": "RS256",
                 "post.logout.redirect.uris": "+",
             },  # Needed to make UserInfo return signed JWT
         },


### PR DESCRIPTION
changes: _rev_

### Proposed Changes

PLAT-2299
- fix post logout redirect uri errors by defaulting to the already defined list of redirect_uris

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
