### PR TITLE
PLAT-2234 Fix kas unit test "Not a package directory" error

### DIFF
--- a/containers/python_base/scripts/monotest
+++ b/containers/python_base/scripts/monotest
@@ -12,7 +12,8 @@
 # Usage: scripts/monotest [--coverage] <package dir>
 
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
-PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+PROJECT_ROOT="$(cd "$TOOLS_DIR"/../ >/dev/null && pwd)"
 export PATH="$PATH:$TOOLS_DIR"
 
 monolog TRACE "monotest: [$0 $*]"

--- a/containers/python_base/scripts/monotest
+++ b/containers/python_base/scripts/monotest
@@ -17,7 +17,9 @@ export PATH="$PATH:$TOOLS_DIR"
 
 monolog TRACE "monotest: [$0 $*]"
 
+monolog INFO "monotest: PROJECT ROOT before gen keys [${PROJECT_ROOT}]"
 genkeys-if-needed || exit 1
+monolog INFO "monotest: PROJECT ROOT after gen keys [${PROJECT_ROOT}]"
 
 export packages_under_test=()
 export coverage=
@@ -117,7 +119,9 @@ _single_package() {
   fi
 }
 
+monolog INFO "monotest: PROJECT ROOT before for loop [${PROJECT_ROOT}]"
 for p in "${packages_under_test[@]}"; do
+  monolog INFO "monotest: PROJECT ROOT in for loop [${PROJECT_ROOT}]"
   _single_package "$p"
   rval=$?
   if [[ $rval -ne 0 ]]; then

--- a/containers/python_base/scripts/monotest
+++ b/containers/python_base/scripts/monotest
@@ -90,8 +90,9 @@ _single_pytest() {
 
 _single_package() {
   monolog TRACE "_single_package: [$*]"
+  monolog INFO "PROJECT ROOT: [${PROJECT_ROOT}]"
   if [ ! -d "${PROJECT_ROOT}/$1" ]; then
-    monolog ERROR "Not a package directory [${PROJECT_ROOT}/$1]"
+    monolog ERROR "monotest: Not a package directory [${PROJECT_ROOT}/$1]"
     exit 1
   fi
 

--- a/containers/python_base/scripts/monotest
+++ b/containers/python_base/scripts/monotest
@@ -91,7 +91,7 @@ _single_pytest() {
 _single_package() {
   monolog TRACE "_single_package: [$*]"
   if [ ! -d "${PROJECT_ROOT}/$1" ]; then
-    monolog ERROR "monotest: Not a package directory [${PROJECT_ROOT}/$1]"
+    monolog ERROR "Not a package directory [${PROJECT_ROOT}/$1]"
     exit 1
   fi
 

--- a/containers/python_base/scripts/monotest
+++ b/containers/python_base/scripts/monotest
@@ -12,15 +12,12 @@
 # Usage: scripts/monotest [--coverage] <package dir>
 
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
-TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 PROJECT_ROOT="$(cd "$TOOLS_DIR"/../ >/dev/null && pwd)"
 export PATH="$PATH:$TOOLS_DIR"
 
 monolog TRACE "monotest: [$0 $*]"
 
-monolog INFO "monotest: PROJECT ROOT before gen keys [${PROJECT_ROOT}]"
 genkeys-if-needed || exit 1
-monolog INFO "monotest: PROJECT ROOT after gen keys [${PROJECT_ROOT}]"
 
 export packages_under_test=()
 export coverage=
@@ -93,7 +90,6 @@ _single_pytest() {
 
 _single_package() {
   monolog TRACE "_single_package: [$*]"
-  monolog INFO "PROJECT ROOT: [${PROJECT_ROOT}]"
   if [ ! -d "${PROJECT_ROOT}/$1" ]; then
     monolog ERROR "monotest: Not a package directory [${PROJECT_ROOT}/$1]"
     exit 1
@@ -120,9 +116,7 @@ _single_package() {
   fi
 }
 
-monolog INFO "monotest: PROJECT ROOT before for loop [${PROJECT_ROOT}]"
 for p in "${packages_under_test[@]}"; do
-  monolog INFO "monotest: PROJECT ROOT in for loop [${PROJECT_ROOT}]"
   _single_package "$p"
   rval=$?
   if [[ $rval -ne 0 ]]; then


### PR DESCRIPTION
PLAT-2234

Kas unit tests failing with "Not a package directory [/containers/kas/kas_app]" -- its missing the PROJECT_ROOT var

In the CI output you can see the real issue is that calling git to retrieve the PROJECT_ROOT results in `fatal: detected dubious ownership in repository at '/mnt'` -- full error in comment below

Solve by changing the way we get PROJECT_ROOT -- use the same method as genkeys_if_needed

