### PR TITLE
PLAT-2122 Use a constant org id for audit logging

### DIFF
--- a/containers/kas/kas_app/tdf3_kas_app/plugins/audit_hooks.py
+++ b/containers/kas/kas_app/tdf3_kas_app/plugins/audit_hooks.py
@@ -19,6 +19,8 @@ from tdf3_kas_core.errors import AuthorizationError
 
 logger = logging.getLogger(__name__)
 
+ORG_ID = os.getenv("CONFIG_ORG_ID", str(uuid.uuid4()))
+
 
 def audit_hook(function_name, return_value, data, context, *args, **kwargs):
 
@@ -32,7 +34,7 @@ def audit_hook(function_name, return_value, data, context, *args, **kwargs):
             "tdf_id": "",
             "tdf_name": None,
             "owner_id": "",
-            "owner_org_id": None,
+            "owner_org_id": ORG_ID,
             "transaction_type": "create",
             "action_type": "decrypt",
             "tdf_attributes": {"dissem": [], "attrs": []},
@@ -67,7 +69,7 @@ def err_audit_hook(
             "tdf_id": "",
             "tdf_name": None,
             "owner_id": "",
-            "owner_org_id": None,
+            "owner_org_id": ORG_ID,
             "transaction_type": "create_error",
             "action_type": "access_denied",
             "tdf_attributes": {"dissem": [], "attrs": []},


### PR DESCRIPTION
changes: _rev_

### Proposed Changes

PLAT-2122 -- use a constant org id (default random or passed in by env var), instead of none/null

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
