### PR TITLE
PLAT-2122 Use policy uuid as tdf id in audit logging

### DIFF
--- a/containers/kas/kas_app/requirements.txt
+++ b/containers/kas/kas_app/requirements.txt
@@ -1,7 +1,7 @@
 -i https://pypi.org/simple
 attrs==21.4.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 bitstruct==8.14.1
-certifi==2022.5.18.1; python_version >= '3.6'
+certifi==2022.12.07; python_version >= '3.6'
 cffi==1.15.0
 charset-normalizer==2.0.12; python_version >= '3'
 click==8.1.3; python_version >= '3.7'

--- a/containers/kas/kas_app/tdf3_kas_app/plugins/audit_hooks.py
+++ b/containers/kas/kas_app/tdf3_kas_app/plugins/audit_hooks.py
@@ -41,6 +41,7 @@ def audit_hook(function_name, return_value, data, context, *args, **kwargs):
             "actor_attributes": {"npe": True, "actor_id": "", "attrs": []},
         }
 
+        audit_log["tdf_id"] = policy.uuid
         audit_log["tdf_attributes"]["attrs"] = policy.data_attributes.export_raw()
         audit_log["tdf_attributes"]["dissem"] = policy.dissem.list
 
@@ -111,6 +112,7 @@ def err_audit_hook(
 def extract_policy_data_from_tdf3(audit_log, dataJson):
     canonical_policy = dataJson["policy"]
     original_policy = Policy.construct_from_raw_canonical(canonical_policy)
+    audit_log["tdf_id"] = original_policy.uuid
     audit_log["tdf_attributes"]["attrs"] = original_policy.data_attributes.export_raw()
     audit_log["tdf_attributes"]["dissem"] = original_policy.dissem.list
 
@@ -157,6 +159,7 @@ def extract_policy_data_from_nano(audit_log, dataJson, context, key_master):
         policy_data_as_byte.decode("utf-8")
     )
 
+    audit_log["tdf_id"] = original_policy.uuid
     audit_log["tdf_attributes"]["attrs"] = original_policy.data_attributes.export_raw()
     audit_log["tdf_attributes"]["dissem"] = original_policy.dissem.list
 

--- a/containers/kas/kas_app/tdf3_kas_app/plugins/audit_hooks_test.py
+++ b/containers/kas/kas_app/tdf3_kas_app/plugins/audit_hooks_test.py
@@ -32,6 +32,7 @@ TEST_REQUEST_BODY = {
 def test_extract_policy_data_from_tdf():
     new_audit_log = extract_policy_data_from_tdf3(BASE_AUDIT_LOG, TEST_REQUEST_BODY)
 
+    assert new_audit_log["tdf_id"] == "a46dd163-6039-4ef3-9bd3-0ebb3f403954"
     assert new_audit_log["tdf_attributes"]["dissem"] == []
     assert new_audit_log["tdf_attributes"]["attrs"] == [
             {"attribute": "https://example.com/attr/Classification/value/TS"}

--- a/containers/kas/kas_core/requirements.txt
+++ b/containers/kas/kas_core/requirements.txt
@@ -3,7 +3,7 @@
 -e git+https://github.com/virtru/access-pdp@1f7f62667c9ba0451a67b3618a894beedb74ad54#egg=attributes&subdirectory=clients/python/attributes
 attrs==21.4.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 bitstruct==8.15.1
-certifi==2022.5.18.1; python_version >= '3.6'
+certifi==2022.12.07; python_version >= '3.6'
 cffi==1.15.0
 charset-normalizer==2.0.12; python_full_version >= '3.5.0'
 click==8.1.3; python_version >= '3.7'


### PR DESCRIPTION
use uuid from policy as tdf_id in audit logs, bump certifi in kas to fix vuln
### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
