### PR TITLE
Don't require dpop header on upsert, allow other auth strings

### DIFF
--- a/containers/kas/kas_core/tdf3_kas_core/dpop.py
+++ b/containers/kas/kas_core/tdf3_kas_core/dpop.py
@@ -68,7 +68,9 @@ def validate_dpop(dpop, key_master, request=connexion.request, do_oidc=False):
     bearer, _, id_jwt = auth_header.partition(" ")
     logger.info("id_jwt: [%s], dpop: [%s]", id_jwt, dpop)
     if bearer != "Bearer" or not looks_like_jwt(id_jwt):
-        raise UnauthorizedError("Invalid auth header")
+        if do_oidc:
+            raise UnauthorizedError("Missing auth header")
+        return False
     verifier_key = fetch_realm_key_by_jwt(id_jwt, key_master)
     jwt_decoded = authorized_v2(verifier_key, id_jwt)
     logger.debug("jwt_decoded: [%s]", jwt_decoded)

--- a/containers/kas/kas_core/tdf3_kas_core/dpop.py
+++ b/containers/kas/kas_core/tdf3_kas_core/dpop.py
@@ -69,7 +69,7 @@ def validate_dpop(dpop, key_master, request=connexion.request, do_oidc=False):
     logger.info("id_jwt: [%s], dpop: [%s]", id_jwt, dpop)
     if bearer != "Bearer" or not looks_like_jwt(id_jwt):
         if do_oidc:
-            raise UnauthorizedError("Missing auth header")
+            raise UnauthorizedError("Invalid auth header")
         return False
     verifier_key = fetch_realm_key_by_jwt(id_jwt, key_master)
     jwt_decoded = authorized_v2(verifier_key, id_jwt)

--- a/containers/kas/kas_core/tdf3_kas_core/dpop_test.py
+++ b/containers/kas/kas_core/tdf3_kas_core/dpop_test.py
@@ -53,10 +53,14 @@ def test_validate_dpop_no_auth():
 
 def test_validate_dpop_malformed_auth():
     with pytest.raises(UnauthorizedError, match=r".*Invalid auth.*"):
-        validate_dpop("", keys, MockRequest({"authorization": "Barely a.b.c"}))
+        validate_dpop("", keys, MockRequest({"authorization": "Barely a.b.c"}), do_oidc=True)
 
 
 def test_validate_dpop_malformed_auth_2():
+    assert not validate_dpop("", keys, MockRequest({"authorization": "Barely a.b.c"}))
+
+
+def test_validate_dpop_malformed_auth_3():
     with pytest.raises(UnauthorizedError, match=r".*Invalid JWT.*"):
         validate_dpop("", keys, MockRequest({"authorization": "Bearer a.b.c"}))
 

--- a/containers/kas/kas_core/tdf3_kas_core/web/upsert.py
+++ b/containers/kas/kas_core/tdf3_kas_core/web/upsert.py
@@ -43,12 +43,12 @@ def upsert_helper(body, mode="upsert"):
 
 
 @run_service_with_exceptions
-def upsert(body, *, dpop):
+def upsert(body, *, dpop=None):
     validate_dpop(dpop, Kas.get_instance()._key_master)
     return upsert_helper(body, "upsert")
 
 
 @run_service_with_exceptions
-def upsert_v2(body, *, dpop):
+def upsert_v2(body, *, dpop=None):
     validate_dpop(dpop, Kas.get_instance()._key_master)
     return upsert_helper(body, "upsert_v2")


### PR DESCRIPTION
- Make dpop default to none for upsert to match rewrap
- allow other auth strings if not do_oidc ex: [Authorization: SomeOrg 123456]


### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
