### PR TITLE
PLAT-2385 kas middleware for dpop check

### DIFF
--- a/containers/kas/kas_app/tdf3_kas_app/kas_app.py
+++ b/containers/kas/kas_app/tdf3_kas_app/kas_app.py
@@ -103,7 +103,7 @@ def app(name):
     access_pdp_health = access_pdp_healthz_plugin.AccessPDPHealthzPlugin()
     kas.use_healthz_plugin(access_pdp_health)
 
-    kas.use_pop_middleware(validate_dpop)
+    kas.add_middleware(validate_dpop)
 
     if AUDIT_ENABLED:
         kas.use_post_rewrap_hook(audit_hooks.audit_hook)

--- a/containers/kas/kas_app/tdf3_kas_app/kas_app.py
+++ b/containers/kas/kas_app/tdf3_kas_app/kas_app.py
@@ -7,6 +7,7 @@ from importlib import metadata
 from importlib.metadata import PackageNotFoundError
 
 from tdf3_kas_core import Kas
+from tdf3_kas_core import validate_dpop
 
 from .plugins import (
     opentdf_attr_authority_plugin,
@@ -101,6 +102,8 @@ def app(name):
 
     access_pdp_health = access_pdp_healthz_plugin.AccessPDPHealthzPlugin()
     kas.use_healthz_plugin(access_pdp_health)
+
+    kas.use_pop_middleware(validate_dpop)
 
     if AUDIT_ENABLED:
         kas.use_post_rewrap_hook(audit_hooks.audit_hook)

--- a/containers/kas/kas_core/tdf3_kas_core/__init__.py
+++ b/containers/kas/kas_core/tdf3_kas_core/__init__.py
@@ -7,4 +7,6 @@ from .models import Context  # noqa: F401
 from .models import WrappedKey  # noqa: F401
 from .models import AttributeValue  # noqa: F401
 
+from .dpop import validate_dpop # noqa: F401
+
 from .kas import Kas  # noqa: F401

--- a/containers/kas/kas_core/tdf3_kas_core/errors.py
+++ b/containers/kas/kas_core/tdf3_kas_core/errors.py
@@ -55,6 +55,8 @@ class KeyNotFoundError(Error):
 class JWTError(Error):
     """Raise when there is some failure creating or verifying a JWT."""
 
+class MiddlewareIsBadError(Error):
+    """Throw when something non-callable is provided."""
 
 class PluginBackendError(Error):
     """Generic 502 errors, for use by plugins."""

--- a/containers/kas/kas_core/tdf3_kas_core/kas.py
+++ b/containers/kas/kas_core/tdf3_kas_core/kas.py
@@ -161,6 +161,7 @@ class Kas(object):
         self._upsert_plugins_v2 = []
         self._post_rewrap_hook = post_rewrap_v2_hook_default
         self._err_rewrap_hook = lambda *args: None
+        self._pop_middleware = lambda *args: None
         self._key_master = KeyMaster()
 
         # These callables and the flask app will be constructed by the app() method after configuration
@@ -257,6 +258,10 @@ class Kas(object):
         """ Add a hook called when rewrap returns an error """
         if callable(hook):
             self._err_rewrap_hook = hook
+
+    def use_pop_middleware(self, middleware):
+        if callable(middleware):
+            self._pop_middleware = middleware
 
     def get_session_healthz(self):
         """return the callable to process healthz requests."""

--- a/containers/kas/kas_core/tdf3_kas_core/kas.py
+++ b/containers/kas/kas_core/tdf3_kas_core/kas.py
@@ -161,7 +161,7 @@ class Kas(object):
         self._upsert_plugins_v2 = []
         self._post_rewrap_hook = post_rewrap_v2_hook_default
         self._err_rewrap_hook = lambda *args: None
-        self._pop_middleware = lambda *args: None
+        self._middleware = lambda *args: None
         self._key_master = KeyMaster()
 
         # These callables and the flask app will be constructed by the app() method after configuration
@@ -259,9 +259,9 @@ class Kas(object):
         if callable(hook):
             self._err_rewrap_hook = hook
 
-    def use_pop_middleware(self, middleware):
-        if callable(middleware):
-            self._pop_middleware = middleware
+    def add_middleware(self, middleware):
+        if callable(middleware) or None:
+            self._middleware = middleware
 
     def get_session_healthz(self):
         """return the callable to process healthz requests."""

--- a/containers/kas/kas_core/tdf3_kas_core/kas.py
+++ b/containers/kas/kas_core/tdf3_kas_core/kas.py
@@ -21,6 +21,7 @@ from .models import KeyMaster
 
 from .errors import PluginIsBadError
 from .errors import ServerStartupError
+from .errors import MiddlewareIsBadError
 
 from .abstractions import (
     AbstractHealthzPlugin,
@@ -161,7 +162,7 @@ class Kas(object):
         self._upsert_plugins_v2 = []
         self._post_rewrap_hook = post_rewrap_v2_hook_default
         self._err_rewrap_hook = lambda *args: None
-        self._middleware = lambda *args: None
+        self._middleware = None
         self._key_master = KeyMaster()
 
         # These callables and the flask app will be constructed by the app() method after configuration
@@ -251,17 +252,26 @@ class Kas(object):
 
     def use_post_rewrap_hook(self, hook):
         """ Add a hook called after rewrap completes """
-        if callable(hook):
-            self._post_rewrap_hook = hook
+        if not callable(hook):
+            raise MiddlewareIsBadError("Provided error hook is not callable")
+        self._post_rewrap_hook = hook
 
     def use_err_rewrap_hook(self, hook):
         """ Add a hook called when rewrap returns an error """
-        if callable(hook):
-            self._err_rewrap_hook = hook
+        if not callable(hook):
+            raise MiddlewareIsBadError("Provided error hook is not callable")
+        self._err_rewrap_hook = hook
 
     def add_middleware(self, middleware):
-        if callable(middleware) or None:
-            self._middleware = middleware
+        if not(callable(middleware) or None):
+            raise MiddlewareIsBadError("Provided middleware is not callable")
+        self._middleware = middleware
+
+    def get_middleware(self):
+        """ return the callable middleare """
+        if self._middleware is not None:
+            return self._middleware
+        return lambda *args: None
 
     def get_session_healthz(self):
         """return the callable to process healthz requests."""

--- a/containers/kas/kas_core/tdf3_kas_core/web/rewrap.py
+++ b/containers/kas/kas_core/tdf3_kas_core/web/rewrap.py
@@ -8,8 +8,6 @@ from tdf3_kas_core.schema import get_schema
 from .create_context import create_context
 from .run_service_with_exceptions import run_service_with_exceptions
 
-from ..dpop import validate_dpop
-
 TDF3_REWRAP_SCHEMA = get_schema("tdf3_rewrap_schema")
 logger = logging.getLogger(__name__)
 
@@ -40,11 +38,11 @@ def rewrap_helper(body, session_rewrap):
 
 @run_service_with_exceptions
 def rewrap(body, *, dpop=None):
-    validate_dpop(dpop, Kas.get_instance()._key_master)
+    Kas.get_instance()._pop_middleware(dpop, Kas.get_instance()._key_master)
     return rewrap_helper(body, Kas.get_instance().get_session_rewrap())
 
 
 @run_service_with_exceptions
 def rewrap_v2(body, *, dpop=None):
-    validate_dpop(dpop, Kas.get_instance()._key_master)
+    Kas.get_instance()._pop_middleware(dpop, Kas.get_instance()._key_master)
     return rewrap_helper(body, Kas.get_instance().get_session_rewrap_v2())

--- a/containers/kas/kas_core/tdf3_kas_core/web/rewrap.py
+++ b/containers/kas/kas_core/tdf3_kas_core/web/rewrap.py
@@ -38,11 +38,11 @@ def rewrap_helper(body, session_rewrap):
 
 @run_service_with_exceptions
 def rewrap(body, *, dpop=None):
-    Kas.get_instance()._pop_middleware(dpop, Kas.get_instance()._key_master)
+    Kas.get_instance()._middleware(dpop, Kas.get_instance()._key_master)
     return rewrap_helper(body, Kas.get_instance().get_session_rewrap())
 
 
 @run_service_with_exceptions
 def rewrap_v2(body, *, dpop=None):
-    Kas.get_instance()._pop_middleware(dpop, Kas.get_instance()._key_master)
+    Kas.get_instance()._middleware(dpop, Kas.get_instance()._key_master)
     return rewrap_helper(body, Kas.get_instance().get_session_rewrap_v2())

--- a/containers/kas/kas_core/tdf3_kas_core/web/rewrap.py
+++ b/containers/kas/kas_core/tdf3_kas_core/web/rewrap.py
@@ -38,11 +38,11 @@ def rewrap_helper(body, session_rewrap):
 
 @run_service_with_exceptions
 def rewrap(body, *, dpop=None):
-    Kas.get_instance()._middleware(dpop, Kas.get_instance()._key_master)
+    Kas.get_instance().get_middleware()(dpop, Kas.get_instance()._key_master)
     return rewrap_helper(body, Kas.get_instance().get_session_rewrap())
 
 
 @run_service_with_exceptions
 def rewrap_v2(body, *, dpop=None):
-    Kas.get_instance()._middleware(dpop, Kas.get_instance()._key_master)
+    Kas.get_instance().get_middleware()(dpop, Kas.get_instance()._key_master)
     return rewrap_helper(body, Kas.get_instance().get_session_rewrap_v2())

--- a/containers/kas/kas_core/tdf3_kas_core/web/run_service_with_exceptions.py
+++ b/containers/kas/kas_core/tdf3_kas_core/web/run_service_with_exceptions.py
@@ -19,6 +19,7 @@ from tdf3_kas_core.errors import InvalidBindingError
 from tdf3_kas_core.errors import JWTError
 from tdf3_kas_core.errors import KeyAccessError
 from tdf3_kas_core.errors import KeyNotFoundError
+from tdf3_kas_core.errors import MiddlewareIsBadError
 from tdf3_kas_core.errors import PluginBackendError
 from tdf3_kas_core.errors import PluginIsBadError
 from tdf3_kas_core.errors import PluginFailedError
@@ -133,6 +134,10 @@ def run_service_with_exceptions(service=None, *, success=200):
 
         except KeyNotFoundError as err:
             return handle_exception(403, err)
+
+        except MiddlewareIsBadError as err:
+            # Error in the middleware configuration.
+            return handle_exception(500, err)
 
         except PluginBackendError as err:
             # Like a 500, but for somebody else.

--- a/containers/kas/kas_core/tdf3_kas_core/web/run_service_with_exceptions_test.py
+++ b/containers/kas/kas_core/tdf3_kas_core/web/run_service_with_exceptions_test.py
@@ -16,6 +16,7 @@ from tdf3_kas_core.errors import InvalidBindingError
 from tdf3_kas_core.errors import KeyAccessError
 from tdf3_kas_core.errors import KeyNotFoundError
 from tdf3_kas_core.errors import JWTError
+from tdf3_kas_core.errors import MiddlewareIsBadError
 from tdf3_kas_core.errors import PluginBackendError
 from tdf3_kas_core.errors import PluginIsBadError
 from tdf3_kas_core.errors import PluginFailedError
@@ -129,6 +130,14 @@ def test_JWTError(req):
     actual = (run_service_with_exceptions(serv))(req)
     assert isinstance(actual, flask.Response)
     assert actual.status_code == 403
+
+
+def test_MiddlewareIsBadError(req):
+    """Test MiddlewareIsBadError."""
+    serv = create_service(MiddlewareIsBadError)
+    actual = (run_service_with_exceptions(serv))(req)
+    assert isinstance(actual, flask.Response)
+    assert actual.status_code == 500
 
 
 def test_PluginBackendError(req):

--- a/containers/kas/kas_core/tdf3_kas_core/web/upsert.py
+++ b/containers/kas/kas_core/tdf3_kas_core/web/upsert.py
@@ -43,11 +43,11 @@ def upsert_helper(body, mode="upsert"):
 
 @run_service_with_exceptions
 def upsert(body, *, dpop=None):
-    Kas.get_instance()._pop_middleware(dpop, Kas.get_instance()._key_master)
+    Kas.get_instance()._middleware(dpop, Kas.get_instance()._key_master)
     return upsert_helper(body, "upsert")
 
 
 @run_service_with_exceptions
 def upsert_v2(body, *, dpop=None):
-    Kas.get_instance()._pop_middleware(dpop, Kas.get_instance()._key_master)
+    Kas.get_instance()._middleware(dpop, Kas.get_instance()._key_master)
     return upsert_helper(body, "upsert_v2")

--- a/containers/kas/kas_core/tdf3_kas_core/web/upsert.py
+++ b/containers/kas/kas_core/tdf3_kas_core/web/upsert.py
@@ -43,11 +43,11 @@ def upsert_helper(body, mode="upsert"):
 
 @run_service_with_exceptions
 def upsert(body, *, dpop=None):
-    Kas.get_instance()._middleware(dpop, Kas.get_instance()._key_master)
+    Kas.get_instance().get_middleware()(dpop, Kas.get_instance()._key_master)
     return upsert_helper(body, "upsert")
 
 
 @run_service_with_exceptions
 def upsert_v2(body, *, dpop=None):
-    Kas.get_instance()._middleware(dpop, Kas.get_instance()._key_master)
+    Kas.get_instance().get_middleware()(dpop, Kas.get_instance()._key_master)
     return upsert_helper(body, "upsert_v2")

--- a/containers/kas/kas_core/tdf3_kas_core/web/upsert.py
+++ b/containers/kas/kas_core/tdf3_kas_core/web/upsert.py
@@ -4,7 +4,6 @@ import logging
 
 from ..kas import Kas
 from ..schema import get_schema
-from ..dpop import validate_dpop
 
 from .create_context import create_context
 from .run_service_with_exceptions import run_service_with_exceptions
@@ -44,11 +43,11 @@ def upsert_helper(body, mode="upsert"):
 
 @run_service_with_exceptions
 def upsert(body, *, dpop=None):
-    validate_dpop(dpop, Kas.get_instance()._key_master)
+    Kas.get_instance()._pop_middleware(dpop, Kas.get_instance()._key_master)
     return upsert_helper(body, "upsert")
 
 
 @run_service_with_exceptions
 def upsert_v2(body, *, dpop=None):
-    validate_dpop(dpop, Kas.get_instance()._key_master)
+    Kas.get_instance()._pop_middleware(dpop, Kas.get_instance()._key_master)
     return upsert_helper(body, "upsert_v2")


### PR DESCRIPTION
move the dpop check to middleware to allow for more flexibility, can change use different pop check in virtru kas

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
