### PR TITLE
🙈 Allow userId query parameter

### DIFF
--- a/.github/workflows/build-ubi9-images.yaml
+++ b/.github/workflows/build-ubi9-images.yaml
@@ -3,8 +3,6 @@ env:
   CONTAINER_ARCHS: linux/amd64,linux/arm64
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   push:
     branches:
       - main

--- a/common.Tiltfile
+++ b/common.Tiltfile
@@ -67,7 +67,6 @@ def dict_to_helm_set_list(dict):
 # set: dictionary of value_name: value pairs
 # extra_helm_parameters: only valid when devmode=False; passed to underlying `helm update` command
 def backend(values=[], set={}, extra_helm_parameters=[], devmode=False):
-
     #   o8o
     #   `"'
     #  oooo  ooo. .oo.  .oo.    .oooo.    .oooooooo  .ooooo.   .oooo.o
@@ -260,7 +259,7 @@ def backend(values=[], set={}, extra_helm_parameters=[], devmode=False):
                 ("keycloak.image.repository", "keycloak.image.tag"),
                 ("attributes.image.repo", "attributes.image.tag"),
                 ("entitlements.image.repo", "entitlements.image.tag"),
-                ("entitlement_store.image.repo", "entitlement_store.image.tag"),
+                ("entitlement-store.image.repo", "entitlement-store.image.tag"),
                 ("entitlement-pdp.image.repo", "entitlement-pdp.image.tag"),
                 ("entity-resolution.image.repo", "entity-resolution.image.tag"),
                 ("kas.image.repo", "kas.image.tag"),

--- a/containers/kas/kas_core/tdf3_kas_core/api/openapi.yaml
+++ b/containers/kas/kas_core/tdf3_kas_core/api/openapi.yaml
@@ -90,8 +90,14 @@ paths:
         data keys as needed to provide access for entities with a TDF that they
         would like to open.
       operationId: tdf3_kas_core.web.rewrap.rewrap
-      parameters: &dpop-header
-        - in: header
+      parameters:
+        - &user-id-param 
+          in: query
+          name: userId
+          schema:
+            type: string
+        - &dpop-header
+          in: header
           name: dpop
           schema:
             type: string
@@ -137,7 +143,8 @@ paths:
         data keys as needed to provide access for entities with a TDF that they
         would like to open.
       operationId: tdf3_kas_core.web.rewrap.rewrap_v2
-      parameters: *dpop-header
+      parameters:
+        - *dpop-header
       requestBody:
         $ref: "#/components/requestBodies/RewrapV2"
       # security:
@@ -181,7 +188,9 @@ paths:
         The upsert service is a proxy to the back-end services that persist
         policies and keys.
       operationId: tdf3_kas_core.web.upsert.upsert
-      parameters: *dpop-header
+      parameters:
+        - *user-id-param
+        - *dpop-header
       requestBody:
         $ref: "#/components/requestBodies/Upsert"
       responses:
@@ -214,7 +223,8 @@ paths:
         The upsert service is a proxy to the back-end services that persist
         policies and keys.
       operationId: tdf3_kas_core.web.upsert.upsert_v2
-      parameters: *dpop-header
+      parameters:
+        - *dpop-header
       requestBody:
         $ref: "#/components/requestBodies/UpsertV2"
       # security:

--- a/containers/kas/kas_core/tdf3_kas_core/web/rewrap.py
+++ b/containers/kas/kas_core/tdf3_kas_core/web/rewrap.py
@@ -37,7 +37,9 @@ def rewrap_helper(body, session_rewrap):
 
 
 @run_service_with_exceptions
-def rewrap(body, *, dpop=None):
+def rewrap(body, *, dpop=None, userId=None):
+    if userId:
+        logger.info("Legacy user logging in")
     Kas.get_instance().get_middleware()(dpop, Kas.get_instance()._key_master)
     return rewrap_helper(body, Kas.get_instance().get_session_rewrap())
 

--- a/containers/kas/kas_core/tdf3_kas_core/web/upsert.py
+++ b/containers/kas/kas_core/tdf3_kas_core/web/upsert.py
@@ -42,7 +42,9 @@ def upsert_helper(body, mode="upsert"):
 
 
 @run_service_with_exceptions
-def upsert(body, *, dpop=None):
+def upsert(body, *, dpop=None, userId=None):
+    if userId:
+        logger.info("Legacy user logging in")
     Kas.get_instance().get_middleware()(dpop, Kas.get_instance()._key_master)
     return upsert_helper(body, "upsert")
 


### PR DESCRIPTION
There is a bug in most virtru-sdk for javascript clients that currently sends the userId in HMAC requests


### Proposed Changes


### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
