### PR TITLE
Add option for mount config from secret

### DIFF
--- a/charts/keycloak-bootstrap/templates/bootstrap-configmap.yaml
+++ b/charts/keycloak-bootstrap/templates/bootstrap-configmap.yaml
@@ -18,4 +18,6 @@ data:
 {{ toYaml .Values.keycloak.preloadedClients | indent 4 }}
   users.yaml: |-
 {{ toYaml .Values.keycloak.preloadedUsers | indent 4 }}
+{{- else if or .Values.attributes.preloadedAttributes .Values.attributes.preloadedAuthorities .Values.entitlements.realms .Values.keycloak.customConfig .Values.keycloak.preloadedClients .Values.keycloak.preloadedUsers }}
+{{- fail "Conflicting values: setting `existingConfigSecret` ignores other configuration input" }}
 {{- end }}

--- a/charts/keycloak-bootstrap/templates/bootstrap-configmap.yaml
+++ b/charts/keycloak-bootstrap/templates/bootstrap-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingConfigSecret }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -17,4 +18,4 @@ data:
 {{ toYaml .Values.keycloak.preloadedClients | indent 4 }}
   users.yaml: |-
 {{ toYaml .Values.keycloak.preloadedUsers | indent 4 }}
-
+{{- end }}

--- a/charts/keycloak-bootstrap/templates/keycloak-bootstrap-job.yaml
+++ b/charts/keycloak-bootstrap/templates/keycloak-bootstrap-job.yaml
@@ -76,8 +76,13 @@ spec:
               mountPath: /etc/virtru-config
       volumes:
         - name: keycloak-bootstrap-config-volume
+          {{- if .Values.existingConfigSecret }}
+          secret:
+            name: {{ .Values.existingConfigSecret }}
+          {{- else }}
           configMap:
             name: {{ include "keycloak-bootstrap.fullname" . }}-cm
+          {{- end }}
       restartPolicy: Never
       {{- with (coalesce .Values.imagePullSecrets .Values.global.opentdf.common.imagePullSecrets) }}
       imagePullSecrets:

--- a/charts/keycloak-bootstrap/values.yaml
+++ b/charts/keycloak-bootstrap/values.yaml
@@ -58,6 +58,9 @@ opentdf:
 secretRef: |-
   name: {{ template "keycloak-bootstrap.fullname" . }}-secret
 
+# The name of an existing secret containing configuration file keys values.
+existingConfigSecret:
+
 keycloak:
   # -- override for `global.opentdf.common.oidcExternalBaseUrl`
   hostname:


### PR DESCRIPTION
### Proposed Changes
Add value option to load expected config files from a pre-existing secret

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
