### PR TITLE
Extend tdf-client audience for API test purposes

### DIFF
--- a/containers/keycloak-bootstrap/keycloak_bootstrap.py
+++ b/containers/keycloak-bootstrap/keycloak_bootstrap.py
@@ -293,6 +293,7 @@ def createTestClientTDFClient(keycloak_admin):
     logger.info("Created client [%s] as [%s]", client_id, keycloak_client_id)
     addVirtruMappers(keycloak_admin, keycloak_client_id)
     addVirtruClientAudienceMapper(keycloak_admin, keycloak_client_id, "tdf-attributes")
+    addVirtruClientAudienceMapper(keycloak_admin, keycloak_client_id, "tdf-entitlement")
 
 
 def createPreloadedTDFClients(keycloak_admin, keycloak_auth_url, preloaded_clients):


### PR DESCRIPTION
### Proposed Changes
Would like to extend audience for the "tdf-client" client to be able to use generated tokens for Entitlement API test purposes
in scope of PLAT-2454

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
