### PR TITLE
🐛 Fix reviewed branch check

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,9 +21,14 @@ jobs:
       SHA_TAG: "${{ steps.info.outputs.SHA }}"
     timeout-minutes: 5
     steps:
-      - name: This workflow should run only main branch
-        if: github.ref_name != 'main'
-        run: echo This workflow should run only main branch. Please switch from "${{ github.ref_name }}" to main and try again >> $GITHUB_STEP_SUMMARY && exit 1
+      - name: Validate published release is on main (reviewed) branch
+        run: |
+          git fetch origin main:main
+          git fetch --all --tags --force
+          if ! git merge-base --is-ancestor "$RELEASE_TAG" main; then
+            echo "# Invalid release tag [$RELEASE_TAG] - must be on `main` branch" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
 
       - uses: actions/checkout@v3
       - run: echo -e "$EVENT_CONTEXT\n"


### PR DESCRIPTION
- ref will always be the tag, not `main`.


### Proposed Changes


### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
