### PR TITLE
PLAT-2497 Disable ingress object creation when using istio

### DIFF
--- a/charts/attributes/templates/ingress.yaml
+++ b/charts/attributes/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled (not .Values.global.opentdf.common.istio.enabled) -}}
 {{- $fullName := include "attributes.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1

--- a/charts/entitlements/templates/ingress.yaml
+++ b/charts/entitlements/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled (not .Values.global.opentdf.common.istio.enabled) -}}
 {{- $fullName := include "entitlements.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1

--- a/charts/kas/templates/ingress.yaml
+++ b/charts/kas/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled (not .Values.global.opentdf.common.istio.enabled) -}}
 {{- $fullName := include "kas.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
### Proposed Changes
Ingress object should not be created when using istio, only create if istio is disabled

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
