### PR TITLE
Use default client_secret env var with lookup for client id specific …

### DIFF
--- a/charts/keycloak-bootstrap/values.yaml
+++ b/charts/keycloak-bootstrap/values.yaml
@@ -52,7 +52,9 @@ opentdf:
 # -- Expect a secret with following keys:
 # - keycloak_admin_username:
 # - keycloak_admin_password:
-# - CLIENT_SECRET:
+# - CLIENT_SECRET
+# - <client_id>_CLIENT_SECRET: Override for CLIENT_SECRET for specific client.
+# -
 # - ATTRIBUTES_USERNAME:
 # - ATTRIBUTES_PASSWORD:
 secretRef: |-

--- a/containers/keycloak-bootstrap/keycloak_bootstrap.py
+++ b/containers/keycloak-bootstrap/keycloak_bootstrap.py
@@ -33,7 +33,7 @@ kc_internal_url = os.getenv(
 ).rstrip("/")
 pki_browser = os.getenv("ENABLE_PKI_BROWSER", "")
 pki_direct = os.getenv("ENABLE_PKI_DIRECTGRANT", "")
-
+default_client_secret = os.getenv("CLIENT_SECRET", "123-456")
 
 def check_matched(pattern, allData):
     filtered_item = [
@@ -207,7 +207,7 @@ def createTestClientForX509Flow(keycloak_admin):
 def createTestClientForClientCredentialsFlow(
     keycloak_admin, keycloak_auth_url, client_id
 ):
-    client_secret = os.getenv("CLIENT_SECRET", "123-456")
+    client_secret = os.getenv(client_id + "_CLIENT_SECRET", default_client_secret)
     logger.debug("Creating client %s configured for clientcreds flow", client_id)
     keycloak_admin.create_client(
         payload={
@@ -384,7 +384,7 @@ def createTestClientTDFEntitlements(keycloak_admin):
 
 def createTestClientTDFEntityResolution(keycloak_admin):
     client_id = "tdf-entity-resolution-service"
-    client_secret = "123-456"
+    client_secret = os.getenv(client_id + "_CLIENT_SECRET", default_client_secret)
     logger.debug("Creating client %s configured for entity resolution", client_id)
     keycloak_admin.create_client(
         payload={


### PR DESCRIPTION
### Proposed Changes
- Allow for client secrets to be retrieved for each client with CLIENT_SECRET env var backup
- Don't hardcode entity resolution client secret


### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
