### PR TITLE
Tiltfile devmode true when run out of CI

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -35,6 +35,8 @@ cors_origins = {
 
 
 backend(
+    # if not CI then run in developer mode, see env var https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+    devmode=os.getenv("CI") != "true",
     set=dict(
         ingress_enable.items()
         + openapi_enable.items()


### PR DESCRIPTION
### Proposed Changes

if not CI then run in developer mode
- https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
- `CI=true`

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
