### PR TITLE
Keycloak TDF claims mapper - preferred_username null check

### DIFF
--- a/containers/keycloak-protocol-mapper/custom-mapper/src/main/java/com/virtru/keycloak/TdfClaimsMapper.java
+++ b/containers/keycloak-protocol-mapper/custom-mapper/src/main/java/com/virtru/keycloak/TdfClaimsMapper.java
@@ -204,13 +204,16 @@ public class TdfClaimsMapper extends AbstractOIDCProtocolMapper
         // String claimReqType = "min_claims";
         // Right now, for back compat, ALWAYS return full claims by default - later,
         // when/if a reduced claimset is needed, we can default to minClaims
-        logger.debug("USERNAME: [{}], User ID: [{}], ", userSession.getLoginUsername(), userSession.getUser().getId());
+        logger.info("USERNAME: [{}], User ID: [{}], ", userSession.getLoginUsername(), userSession.getUser().getId());
 
         logger.debug("userSession.getNotes CONTENT IS: ");
         for (Map.Entry<String, String> entry : userSession.getNotes().entrySet()) {
             logger.debug("ENTRY IS: {}", entry);
         }
-
+        if (token.getPreferredUsername() == null) {
+            logger.error(IDToken.PREFERRED_USERNAME + " is null");
+            throw new BadRequestException(IDToken.PREFERRED_USERNAME + " is null");
+        }
         // AZP == clientID (always present)
         // SUB = subject (always present, might be == AZP, might not be )
         // Get client ID (or IDs plural, if this is a token that has been exchanged for

--- a/containers/keycloak-protocol-mapper/custom-mapper/src/test/java/com/virtru/keycloak/TdfClaimsMapperTest.java
+++ b/containers/keycloak-protocol-mapper/custom-mapper/src/test/java/com/virtru/keycloak/TdfClaimsMapperTest.java
@@ -121,6 +121,7 @@ public class TdfClaimsMapperTest {
 
     private void assertTransformAccessToken_WithPKHeader() throws Exception {
         AccessToken accessToken = new AccessToken();
+        accessToken.setPreferredUsername("my_preferred_username");
         attributeOIDCProtocolMapper.transformAccessToken(accessToken, protocolMapperModel,
                 keycloakSession, userSessionModel, clientSessionContext);
         Object customClaims = accessToken.getOtherClaims().get("customAttrs");
@@ -147,6 +148,7 @@ public class TdfClaimsMapperTest {
     // secondary clientId list
     private void assertTransformAccessToken_WithPKHeader_DirectGrantSvcAccount() throws Exception {
         AccessToken accessToken = new AccessToken();
+        accessToken.setPreferredUsername("my_preferred_username");
         attributeOIDCProtocolMapper.transformAccessToken(accessToken, protocolMapperModel,
                 keycloakSession, userSessionModel, clientSessionContext);
         Object customClaims = accessToken.getOtherClaims().get("customAttrs");
@@ -167,6 +169,7 @@ public class TdfClaimsMapperTest {
 
     private void assertTransformUserInfo_WithPKHeader() throws Exception {
         AccessToken accessToken = new AccessToken();
+        accessToken.setPreferredUsername("my_preferred_username");
         attributeOIDCProtocolMapper.transformUserInfoToken(accessToken, protocolMapperModel,
                 keycloakSession, userSessionModel, clientSessionContext);
         Object customClaims = accessToken.getOtherClaims().get("customAttrs");

--- a/containers/keycloak-protocol-mapper/custom-mapper/src/test/java/com/virtru/keycloak/TdfClaimsMapperTest.java
+++ b/containers/keycloak-protocol-mapper/custom-mapper/src/test/java/com/virtru/keycloak/TdfClaimsMapperTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
 import org.keycloak.models.*;
 import org.keycloak.models.session.PersistentAuthenticatedClientSessionAdapter;
 import org.keycloak.models.session.PersistentClientSessionModel;
@@ -102,6 +103,20 @@ public class TdfClaimsMapperTest {
     public void testTransformUserInfo_WithPKHeader_ConfigVar() throws Exception {
         commonSetup("12345", true, true, false);
         assertTransformUserInfo_WithPKHeader();
+    }
+
+    @EnabledIfSystemProperty(named = "attributemapperTestMode", matches = "config")
+    @Test
+    public void testTransformAccessToken_WithPreferredUsernameNull() throws Exception {
+        commonSetup("12345", true, false, false);
+        AccessToken accessToken = new AccessToken();
+        assertThrows(BadRequestException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                attributeOIDCProtocolMapper.transformAccessToken(accessToken, protocolMapperModel,
+                        keycloakSession, userSessionModel, clientSessionContext);
+            }
+        });
     }
 
     private void assertTransformAccessToken_WithPKHeader() throws Exception {


### PR DESCRIPTION
### Proposed Changes
https://virtru.atlassian.net/browse/PLAT-2433
- assumedly corrupted clients are giving us nulls in the IDToken (uninitialized), if this happens throw BadRequest exception.

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
