### PR TITLE
Narrow checks for C901 (McCabe complexity)

### DIFF
--- a/containers/kas/kas_core/pyproject.toml
+++ b/containers/kas/kas_core/pyproject.toml
@@ -60,4 +60,9 @@ line-length = 88
 
 [tool.ruff.mccabe]
 # Flag errors (`C901`) whenever the complexity level exceeds 8.
-max-complexity = 39
+max-complexity = 8
+
+[tool.ruff.per-file-ignores]
+"tdf3_kas_core/web/run_service_with_exceptions.py" = ["C901"]
+"tdf3_kas_core/dpop.py" = ["C901"]
+"tdf3_kas_core/services.py" = ["C901"]


### PR DESCRIPTION
### Proposed Changes

Rather than ignoring all [C901](https://beta.ruff.rs/docs/rules/complex-structure/) errors, ignore them in a subset of files for `tdf3_kas_core`.

