### PR TITLE
Revert ingress-ngninx to 4.0.16

### DIFF
--- a/common.Tiltfile
+++ b/common.Tiltfile
@@ -179,8 +179,8 @@ def backend(values=[], set={}, extra_helm_parameters=[], devmode=False):
     helm_remote(
         "ingress-nginx",
         repo_url="https://kubernetes.github.io/ingress-nginx",
-        set=["controller.config.large-client-header-buffers=20 32k"],
-        version="4.2.1",
+        set=["controller.config.large-client-header-buffers=20 32k", "controller.admissionWebhooks.enabled=false"],
+        version="4.0.16",
     )
 
     k8s_resource("ingress-nginx-controller", port_forwards="65432:80")


### PR DESCRIPTION
### Proposed Changes


### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
