### PR TITLE
PLAT-2517 Support different opa configs

### DIFF
--- a/charts/entitlement-pdp/templates/additional-configmap.yaml
+++ b/charts/entitlement-pdp/templates/additional-configmap.yaml
@@ -1,0 +1,15 @@
+{{ if .Values.additionalConfigMap.data -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.additionalConfigMap.name | quote }}
+  labels:
+    {{- include "entitlement-pdp.labels" . | nindent 4 }}
+data:
+{{- if .Values.additionalConfigMap.data }}
+{{- range $index, $content := .Values.additionalConfigMap.data }}
+  {{ $index }}: |-
+{{ $content | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/entitlement-pdp/templates/configmap.yaml
+++ b/charts/entitlement-pdp/templates/configmap.yaml
@@ -41,3 +41,10 @@ data:
     {{ if .Values.opaConfig.policy.useStaticPolicy }}persistence_directory: /opt/entitlement-pdp/policycache{{ end }}
 
 {{ toYaml .Values.opaConfig.extraConfigYaml | indent 4 }}
+
+{{- if .Values.additionalConfigMapData }}
+{{- range $index, $content := .Values.additionalConfigMapData }}
+  {{ $index }}: |-
+{{ $content | indent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/entitlement-pdp/templates/deployment.yaml
+++ b/charts/entitlement-pdp/templates/deployment.yaml
@@ -73,6 +73,9 @@ spec:
           - name: opa-config
             mountPath: {{ .Values.opaConfigMountPath }}
             readOnly: true
+        {{- if .Values.additionalVolumeMounts }}
+          {{- toYaml .Values.additionalVolumeMounts | nindent 10 }} 
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -99,6 +102,9 @@ spec:
             items:
             - key: "opa-config.yaml"
               path: "opa-config.yaml"
+      {{- if .Values.additionalVolumes }}
+        {{- toYaml .Values.additionalVolumes | nindent 8}}
+      {{- end }}
       {{- with (coalesce .Values.imagePullSecrets .Values.global.opentdf.common.imagePullSecrets) }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/entitlement-pdp/values.yaml
+++ b/charts/entitlement-pdp/values.yaml
@@ -129,7 +129,7 @@ config:
 
 # -- Specify additional volumes to mount, this can be used to specify additional
 # storage materials used in the opa config such as trust stores
-additionalVolumes: 
+additionalVolumes:
   # []
   - name: custom-opa-config
     configMap:
@@ -140,7 +140,7 @@ additionalVolumes:
         path: "custom-opa-config.yaml"
 
 # -- Specify where the additional volumes are mounted
-additionalVolumeMounts: 
+additionalVolumeMounts:
   # []
   - name: custom-opa-config
     mountPath: "/etc/opa/custom-config"
@@ -150,7 +150,7 @@ additionalConfigMap:
   # -- The name of the additional config map
   name: "custom-opa-config-map"
   # -- The data to add to the additional config map
-  data: 
+  data:
   # {}
     custom-opa-config.yaml: |-
       services:

--- a/charts/entitlement-pdp/values.yaml
+++ b/charts/entitlement-pdp/values.yaml
@@ -129,7 +129,8 @@ config:
 
 # -- Specify additional volumes to mount, this can be used to specify additional
 # storage materials used in the opa config such as trust stores
-additionalVolumes: #[]
+additionalVolumes: 
+  # []
   - name: custom-opa-config
     configMap:
       name: custom-opa-config-map
@@ -139,7 +140,8 @@ additionalVolumes: #[]
         path: "custom-opa-config.yaml"
 
 # -- Specify where the additional volumes are mounted
-additionalVolumeMounts: #[]
+additionalVolumeMounts: 
+  # []
   - name: custom-opa-config
     mountPath: "/etc/opa/custom-config"
     readOnly: true
@@ -148,7 +150,8 @@ additionalConfigMap:
   # -- The name of the additional config map
   name: "custom-opa-config-map"
   # -- The data to add to the additional config map
-  data: #{}
+  data: 
+  # {}
     custom-opa-config.yaml: |-
       services:
         policy-registry:

--- a/charts/entitlement-pdp/values.yaml
+++ b/charts/entitlement-pdp/values.yaml
@@ -125,50 +125,28 @@ config:
   # -- Open telemetry collector endpoint
   otlpCollectorEndpoint: "opentelemetry-collector.otel.svc:4317"
   # -- Path to opa config yaml
-  opaConfigPath: "/etc/opa/custom-config/custom-opa-config.yaml"
+  opaConfigPath: "/etc/opa/config/opa-config.yaml"
 
 # -- Specify additional volumes to mount, this can be used to specify additional
 # storage materials used in the opa config such as trust stores
-additionalVolumes:
-  # []
-  - name: custom-opa-config
-    configMap:
-      name: custom-opa-config-map
-      # An array of keys from the ConfigMap to create as files
-      items:
-      - key: "custom-opa-config.yaml"
-        path: "custom-opa-config.yaml"
+additionalVolumes: []
+  # Custom opa config example
+  # - name: custom-opa-config
+  #   configMap:
+  #     name: custom-opa-config-map
+  #     # An array of keys from the ConfigMap to create as files
+  #     items:
+  #     - key: "custom-opa-config.yaml"
+  #       path: "custom-opa-config.yaml"
 
 # -- Specify where the additional volumes are mounted
-additionalVolumeMounts:
-  # []
-  - name: custom-opa-config
-    mountPath: "/etc/opa/custom-config"
-    readOnly: true
+additionalVolumeMounts: []
+  # - name: custom-opa-config
+  #   mountPath: "/etc/opa/custom-config"
+  #   readOnly: true
 
 additionalConfigMap:
   # -- The name of the additional config map
-  name: "custom-opa-config-map"
+  name: ""
   # -- The data to add to the additional config map
-  data:
-  # {}
-    custom-opa-config.yaml: |-
-      services:
-        policy-registry:
-          url: https://ghcr.io
-          type: oci
-          credentials:
-            bearer:
-              token: "${OPA_POLICYBUNDLE_PULLCRED}"
-      bundles:
-        entitlement-policy:
-          service: policy-registry
-          resource: ghcr.io/opentdf/entitlement-pdp/entitlements-policybundle:main
-          trigger: "manual"
-          persist: true
-          polling:
-            min_delay_seconds: 60
-            max_delay_seconds: 60
-      persistence_directory: ./policy-cache/
-      decision_logs:
-        console: true
+  data: {}

--- a/charts/entitlement-pdp/values.yaml
+++ b/charts/entitlement-pdp/values.yaml
@@ -73,6 +73,9 @@ ingress:
   # -- Ingress TLS configuration
   tls: null
 
+
+# To pass in your own custom opa config, use additionalVolumes and additionalVolume mounts
+# to mount the config, then update config.opaConfigPath to the location of the mounted config
 opaConfig:
   policy:
     # -- If `useStaticPolicy` is set to `true`, then an OPA config will be generated
@@ -122,4 +125,47 @@ config:
   # -- Open telemetry collector endpoint
   otlpCollectorEndpoint: "opentelemetry-collector.otel.svc:4317"
   # -- Path to opa config yaml
-  opaConfigPath: "/etc/opa/config/opa-config.yaml"
+  opaConfigPath: "/etc/opa/custom-config/custom-opa-config.yaml"
+
+# -- Specify additional volumes to mount, this can be used to specify additional
+# storage materials used in the opa config such as trust stores
+additionalVolumes: #[]
+  - name: custom-opa-config
+    configMap:
+      name: custom-opa-config-map
+      # An array of keys from the ConfigMap to create as files
+      items:
+      - key: "custom-opa-config.yaml"
+        path: "custom-opa-config.yaml"
+
+# -- Specify where the additional volumes are mounted
+additionalVolumeMounts: #[]
+  - name: custom-opa-config
+    mountPath: "/etc/opa/custom-config"
+    readOnly: true
+
+additionalConfigMap:
+  # -- The name of the additional config map
+  name: "custom-opa-config-map"
+  # -- The data to add to the additional config map
+  data: #{}
+    custom-opa-config.yaml: |-
+      services:
+        policy-registry:
+          url: https://ghcr.io
+          type: oci
+          credentials:
+            bearer:
+              token: "${OPA_POLICYBUNDLE_PULLCRED}"
+      bundles:
+        entitlement-policy:
+          service: policy-registry
+          resource: ghcr.io/opentdf/entitlement-pdp/entitlements-policybundle:main
+          trigger: "manual"
+          persist: true
+          polling:
+            min_delay_seconds: 60
+            max_delay_seconds: 60
+      persistence_directory: ./policy-cache/
+      decision_logs:
+        console: true


### PR DESCRIPTION
### Proposed Changes
Add ability to add extra volumes + mounts + config maps to entitlement pdp to support custom opa configs

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
