### PR TITLE
Add ability to add pod annotations for entitlement-pdp and entity-resolution

### DIFF
--- a/charts/entitlement-pdp/templates/deployment.yaml
+++ b/charts/entitlement-pdp/templates/deployment.yaml
@@ -16,6 +16,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "entitlement-pdp.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/entitlement-pdp/values.yaml
+++ b/charts/entitlement-pdp/values.yaml
@@ -150,3 +150,6 @@ additionalConfigMap:
   name: ""
   # -- The data to add to the additional config map
   data: {}
+
+# -- Values for the deployment `spec.template.metadata.annotations` field
+podAnnotations: {}

--- a/charts/entity-resolution/templates/deployment.yaml
+++ b/charts/entity-resolution/templates/deployment.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "entity-resolution.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/entity-resolution/values.yaml
+++ b/charts/entity-resolution/values.yaml
@@ -68,3 +68,6 @@ config:
     clientId: "tdf-entity-resolution-service"
     # -- Using a legacy keycloak version. See https://github.com/Nerzal/gocloak/issues/346
     legacy: false
+
+# -- Values for the deployment `spec.template.metadata.annotations` field
+podAnnotations: {}


### PR DESCRIPTION
### Proposed Changes
Ability to specify pod annotations, helps when using sidecars in openshift

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
