### PR TITLE
PLAT-2605 Change keycloak mapper priority

### DIFF
--- a/containers/keycloak-protocol-mapper/custom-mapper/src/main/java/com/virtru/keycloak/TdfClaimsMapper.java
+++ b/containers/keycloak-protocol-mapper/custom-mapper/src/main/java/com/virtru/keycloak/TdfClaimsMapper.java
@@ -151,8 +151,6 @@ public class TdfClaimsMapper extends AbstractOIDCProtocolMapper
         //
         // We will have to fix `dissems` to properly get rid of this hack.
         
-        // ObjectMapper objectMapper = new ObjectMapper();
-        // logger.info("Mapper token [{}]", objectMapper.writeValueAsString(token));
         token.setSubject(userSession.getUser().getId());
         logger.info("TDF claims mapper triggered");
 

--- a/containers/keycloak-protocol-mapper/custom-mapper/src/main/java/com/virtru/keycloak/TdfClaimsMapper.java
+++ b/containers/keycloak-protocol-mapper/custom-mapper/src/main/java/com/virtru/keycloak/TdfClaimsMapper.java
@@ -42,6 +42,7 @@ import org.keycloak.protocol.oidc.mappers.OIDCAccessTokenMapper;
 import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
 import org.keycloak.protocol.oidc.mappers.OIDCIDTokenMapper;
 import org.keycloak.protocol.oidc.mappers.UserInfoTokenMapper;
+import org.keycloak.protocol.ProtocolMapperUtils;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.representations.IDToken;
 import org.keycloak.representations.JsonWebToken;
@@ -135,6 +136,11 @@ public class TdfClaimsMapper extends AbstractOIDCProtocolMapper
     }
 
     @Override
+    public int getPriority() {
+        return ProtocolMapperUtils.PRIORITY_SCRIPT_MAPPER;
+    }
+
+    @Override
     protected void setClaim(IDToken token, ProtocolMapperModel mappingModel, UserSessionModel userSession,
             KeycloakSession keycloakSession,
             ClientSessionContext clientSessionCtx) {
@@ -144,6 +150,9 @@ public class TdfClaimsMapper extends AbstractOIDCProtocolMapper
         // do this is because of how legacy code expects `dissems` to work.
         //
         // We will have to fix `dissems` to properly get rid of this hack.
+        
+        ObjectMapper objectMapper = new ObjectMapper();
+        logger.info("Mapper token [{}]", objectMapper.writeValueAsString(token));
         token.setSubject(userSession.getUser().getId());
         logger.info("TDF claims mapper triggered");
 

--- a/containers/keycloak-protocol-mapper/custom-mapper/src/main/java/com/virtru/keycloak/TdfClaimsMapper.java
+++ b/containers/keycloak-protocol-mapper/custom-mapper/src/main/java/com/virtru/keycloak/TdfClaimsMapper.java
@@ -151,8 +151,8 @@ public class TdfClaimsMapper extends AbstractOIDCProtocolMapper
         //
         // We will have to fix `dissems` to properly get rid of this hack.
         
-        ObjectMapper objectMapper = new ObjectMapper();
-        logger.info("Mapper token [{}]", objectMapper.writeValueAsString(token));
+        // ObjectMapper objectMapper = new ObjectMapper();
+        // logger.info("Mapper token [{}]", objectMapper.writeValueAsString(token));
         token.setSubject(userSession.getUser().getId());
         logger.info("TDF claims mapper triggered");
 


### PR DESCRIPTION
### Proposed Changes
The default priority is 0 -- we need our mapper to run last so set the priority high

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
