### PR TITLE
🧽 Reduce usage of helper function

### DIFF
--- a/containers/kas/kas_core/tdf3_kas_core/conftest.py
+++ b/containers/kas/kas_core/tdf3_kas_core/conftest.py
@@ -19,11 +19,31 @@ from .util import get_public_key_from_disk
 from .util import get_private_key_from_disk
 from .util import generate_hmac_digest
 
-public_key = get_public_key_from_disk("test")
-private_key = get_private_key_from_disk("test")
+__public_key = get_public_key_from_disk("test")
+__private_key = get_private_key_from_disk("test")
 
-entity_public_key = get_public_key_from_disk("test_alt")
-entity_private_key = get_private_key_from_disk("test_alt")
+__entity_public_key = get_public_key_from_disk("test_alt")
+__entity_private_key = get_private_key_from_disk("test_alt")
+
+
+@pytest.fixture
+def public_key():
+    return __public_key
+
+
+@pytest.fixture
+def private_key():
+    return __private_key
+
+
+@pytest.fixture
+def entity_public_key():
+    return __entity_public_key
+
+
+@pytest.fixture
+def entity_private_key():
+    return __entity_private_key
 
 
 @pytest.fixture
@@ -42,7 +62,7 @@ def policy():
 
 
 @pytest.fixture
-def entity():
+def entity(public_key):
     """Construct an entity object."""
     user_id = "coyote@acme.com"
     attribute1 = (
@@ -73,7 +93,7 @@ def key_access_remote():
 
 
 @pytest.fixture
-def key_access_wrapped():
+def key_access_wrapped(public_key, private_key):
     """Generate an access key for a wrapped type."""
     plain_key = b"This-is-the-good-key"
     wrapped_key = aes_encrypt_sha1(plain_key, public_key)

--- a/containers/kas/kas_core/tdf3_kas_core/models/adjudicator/adjudicator_test.py
+++ b/containers/kas/kas_core/tdf3_kas_core/models/adjudicator/adjudicator_test.py
@@ -10,12 +10,7 @@ from tdf3_kas_core.models import AttributePolicyCache
 
 from tdf3_kas_core.errors import AuthorizationError
 
-from tdf3_kas_core.util import get_public_key_from_disk
-
 from .adjudicator import Adjudicator
-
-
-PUBLIC_KEY = get_public_key_from_disk("test")
 
 
 def test_adjudicator_construction_normal():
@@ -27,7 +22,7 @@ def test_adjudicator_construction_normal():
 # >>>>>>>>>> ALL OF <<<<<<<<<<<<<<<<<<
 
 
-def test_adjudicator_allows_access_wildcard_dissem():
+def test_adjudicator_allows_access_wildcard_dissem(public_key):
     """Test denies access."""
     # config = AttributePolicyConfig(POLICY_CONFIG_SAMPLE)
     cache = AttributePolicyCache()
@@ -37,14 +32,14 @@ def test_adjudicator_allows_access_wildcard_dissem():
     print("===== Policy")
     print(policy.dissem.list)
 
-    entity = Entity("email2@example.com", PUBLIC_KEY, EntityAttributes())
+    entity = Entity("email2@example.com", public_key, EntityAttributes())
     print("===== Entity")
     print(entity.user_id)
 
     assert adjudicator.can_access(policy, entity) is True
 
 
-def test_adjudicator_allows_access_from_dissem():
+def test_adjudicator_allows_access_from_dissem(public_key):
     """Test denies access."""
     cache = AttributePolicyCache()
     adjudicator = Adjudicator(cache)
@@ -59,7 +54,7 @@ def test_adjudicator_allows_access_from_dissem():
     print("===== Policy")
     print(policy.dissem.list)
 
-    entity = Entity("email2@example.com", PUBLIC_KEY, EntityAttributes())
+    entity = Entity("email2@example.com", public_key, EntityAttributes())
 
     print("===== Entity")
     print(entity.user_id)
@@ -67,7 +62,7 @@ def test_adjudicator_allows_access_from_dissem():
     assert adjudicator.can_access(policy, entity) is True
 
 
-def test_adjudicator_denies_access_from_dissem():
+def test_adjudicator_denies_access_from_dissem(public_key):
     """Test denies access."""
     cache = AttributePolicyCache()
     adjudicator = Adjudicator(cache)
@@ -80,7 +75,7 @@ def test_adjudicator_denies_access_from_dissem():
     ]
     print("===== Policy")
     print(policy.dissem.list)
-    entity = Entity("foo@bar.com", PUBLIC_KEY, EntityAttributes())
+    entity = Entity("foo@bar.com", public_key, EntityAttributes())
     print("===== Entity")
     print(entity.user_id)
 
@@ -95,7 +90,7 @@ all_of_config = [
 ]
 
 
-def test_adjudicator_grants_access_allof_attribute():
+def test_adjudicator_grants_access_allof_attribute(public_key):
     """Test grants access with an all-of attribute value."""
     cache = AttributePolicyCache()
     cache.load_config(all_of_config)
@@ -113,11 +108,11 @@ def test_adjudicator_grants_access_allof_attribute():
             {"attribute": "https://example.com/attr/NTK/value/financial"},
         ]
     )
-    entity = Entity("doesn't_matter", PUBLIC_KEY, entity_attributes)
+    entity = Entity("doesn't_matter", public_key, entity_attributes)
     assert adjudicator.can_access(policy, entity) is True
 
 
-def test_adjudicator_denies_access_allof_attribute():
+def test_adjudicator_denies_access_allof_attribute(public_key):
     """Test denies access with wrong any-of attribute value."""
     cache = AttributePolicyCache()
     cache.load_config(all_of_config)
@@ -132,7 +127,7 @@ def test_adjudicator_denies_access_allof_attribute():
     entity_attributes = EntityAttributes.create_from_list(
         [{"attribute": "https://example.com/attr/NTK/value/projx"}]
     )
-    entity = Entity("doesn't_matter", PUBLIC_KEY, entity_attributes)
+    entity = Entity("doesn't_matter", public_key, entity_attributes)
     with pytest.raises(AuthorizationError):
         adjudicator.can_access(policy, entity)
 
@@ -144,7 +139,7 @@ any_of_config = [
 ]
 
 
-def test_adjudicator_grants_access_anyof_attribute():
+def test_adjudicator_grants_access_anyof_attribute(public_key):
     """Test grants access with an any-of attribute value."""
     cache = AttributePolicyCache()
     cache.load_config(any_of_config)
@@ -165,11 +160,11 @@ def test_adjudicator_grants_access_anyof_attribute():
             {"attribute": "https://example.com/attr/Rel/value/AUS"},
         ]
     )
-    entity = Entity("doesn't_matter", PUBLIC_KEY, entity_attributes)
+    entity = Entity("doesn't_matter", public_key, entity_attributes)
     assert adjudicator.can_access(policy, entity) is True
 
 
-def test_adjudicator_denies_access_anyof_attribute():
+def test_adjudicator_denies_access_anyof_attribute(public_key):
     """Test denies access with wrong any-of attribute value."""
     cache = AttributePolicyCache()
     cache.load_config(any_of_config)
@@ -185,7 +180,7 @@ def test_adjudicator_denies_access_anyof_attribute():
     entity_attributes = EntityAttributes.create_from_list(
         [{"attribute": "https://example.com/attr/Rel/value/AUS"}]
     )
-    entity = Entity("doesn't_matter", PUBLIC_KEY, entity_attributes)
+    entity = Entity("doesn't_matter", public_key, entity_attributes)
     with pytest.raises(AuthorizationError):
         adjudicator.can_access(policy, entity)
 
@@ -202,7 +197,7 @@ hierarchy_config = [
 ]
 
 
-def test_adjudicator_grants_access_hierarchy_attribute_equal():
+def test_adjudicator_grants_access_hierarchy_attribute_equal(public_key):
     """Test hierarchy decision."""
     cache = AttributePolicyCache()
     cache.load_config(hierarchy_config)
@@ -214,11 +209,11 @@ def test_adjudicator_grants_access_hierarchy_attribute_equal():
     entity_attributes = EntityAttributes.create_from_list(
         [{"attribute": "https://example.com/attr/classif/value/S"}]
     )
-    entity = Entity("doesn't_matter", PUBLIC_KEY, entity_attributes)
+    entity = Entity("doesn't_matter", public_key, entity_attributes)
     assert adjudicator.can_access(policy, entity) is True
 
 
-def test_adjudicator_grants_access_hierarchy_entity_attribute_greater():
+def test_adjudicator_grants_access_hierarchy_entity_attribute_greater(public_key):
     """Test hierarchy decision."""
     cache = AttributePolicyCache()
     cache.load_config(hierarchy_config)
@@ -230,11 +225,11 @@ def test_adjudicator_grants_access_hierarchy_entity_attribute_greater():
     entity_attributes = EntityAttributes.create_from_list(
         [{"attribute": "https://example.com/attr/classif/value/TS"}]
     )
-    entity = Entity("doesn't_matter", PUBLIC_KEY, entity_attributes)
+    entity = Entity("doesn't_matter", public_key, entity_attributes)
     assert adjudicator.can_access(policy, entity) is True
 
 
-def test_adjudicator_denies_access_hierarchy_entity_attribute_lesser():
+def test_adjudicator_denies_access_hierarchy_entity_attribute_lesser(public_key):
     """Test hierarchy decision."""
     cache = AttributePolicyCache()
     cache.load_config(hierarchy_config)
@@ -246,6 +241,6 @@ def test_adjudicator_denies_access_hierarchy_entity_attribute_lesser():
     entity_attributes = EntityAttributes.create_from_list(
         [{"attribute": "https://example.com/attr/classif/value/C"}]
     )
-    entity = Entity("doesn't_matter", PUBLIC_KEY, entity_attributes)
+    entity = Entity("doesn't_matter", public_key, entity_attributes)
     with pytest.raises(AuthorizationError):
         adjudicator.can_access(policy, entity)

--- a/containers/kas/kas_core/tdf3_kas_core/models/claims/claims_test.py
+++ b/containers/kas/kas_core/tdf3_kas_core/models/claims/claims_test.py
@@ -3,18 +3,15 @@
 import pytest
 from cryptography.hazmat.primitives import serialization
 
-from tdf3_kas_core.util import get_public_key_from_disk
-
 from tdf3_kas_core.errors import ClaimsError
 from tdf3_kas_core.models import ClaimsAttributes
 
 from .claims import Claims
 
 
-def test_claims_constructor():
+def test_claims_constructor(public_key):
     """Test the basic constructor."""
     user_id = "Hey It's Me"
-    public_key = get_public_key_from_disk("test")
     attributes = {}
     attributes[user_id] = ClaimsAttributes()
     actual = Claims(user_id, public_key, attributes)
@@ -23,16 +20,15 @@ def test_claims_constructor():
     assert actual.entity_attributes == attributes
 
 
-def test_claims_constructor_bad_id():
+def test_claims_constructor_bad_id(public_key):
     """Test the basic constructor."""
     user_id = {}
-    public_key = get_public_key_from_disk("test")
     attributes = ClaimsAttributes()
     with pytest.raises(ClaimsError):
         Claims(user_id, public_key, attributes)
 
 
-def test_claims_constructor_bad_key():
+def test_claims_constructor_bad_key(public_key):
     """Test the basic constructor."""
     user_id = "Hey It's Me"
     public_key = "Public key String"
@@ -41,19 +37,17 @@ def test_claims_constructor_bad_key():
         Claims(user_id, public_key, attributes)
 
 
-def test_claims_no_attributes():
+def test_claims_no_attributes(public_key):
     """Test the basic constructor."""
     user_id = "Hey It's Me"
-    public_key = get_public_key_from_disk("test")
     attributes = ["one", "two"]
     with pytest.raises(ClaimsError):
         Claims(user_id, public_key, attributes)
 
 
-def test_claims_constructor_with_attributes():
+def test_claims_constructor_with_attributes(public_key):
     """Test the basic constructor."""
     user_id = "Hey It's Me"
-    public_key = get_public_key_from_disk("test")
     attribute1 = (
         "https://aa.virtru.com/attr/unique-identifier"
         "/value/7b738968-131a-4de9-b4a1-c922f60583e3"
@@ -88,8 +82,7 @@ def test_claims_constructor_with_attributes():
     assert attr2.value == "7b738968-131a-4de9-b4a1-c922f60583e3"
 
 
-def make_claims_object():
-    public_key = get_public_key_from_disk("test")
+def make_claims_object(public_key):
     data = {
         "sub": "user@virtru.com",
         "tdf_claims": {
@@ -131,7 +124,8 @@ def make_claims_object():
     return data
 
 
-def test_load_from_raw_data_as_dict():
+def test_load_from_raw_data_as_dict(public_key):
     """Test load_from_raw_data.  Raw data as a dict."""
-    data = make_claims_object()
+    data = make_claims_object(public_key)
     actual = Claims.load_from_raw_data(data)
+    assert actual.user_id == "user@virtru.com"

--- a/containers/kas/kas_core/tdf3_kas_core/models/entity/entity_test.py
+++ b/containers/kas/kas_core/tdf3_kas_core/models/entity/entity_test.py
@@ -5,7 +5,6 @@ import pytest
 from cryptography.hazmat.primitives import serialization
 
 import tdf3_kas_core
-from tdf3_kas_core.util import get_public_key_from_disk, get_private_key_from_disk
 
 from tdf3_kas_core.errors import EntityError
 from tdf3_kas_core.models import EntityAttributes
@@ -13,10 +12,9 @@ from tdf3_kas_core.models import EntityAttributes
 from .entity import Entity
 
 
-def test_entity_constructor():
+def test_entity_constructor(public_key):
     """Test the basic constructor."""
     user_id = "Hey It's Me"
-    public_key = get_public_key_from_disk("test")
     attributes = EntityAttributes()
     actual = Entity(user_id, public_key, attributes)
     assert actual.user_id == user_id
@@ -24,10 +22,9 @@ def test_entity_constructor():
     assert actual.attributes == attributes
 
 
-def test_entity_constructor_bad_id():
+def test_entity_constructor_bad_id(public_key):
     """Test the basic constructor."""
     user_id = {}
-    public_key = get_public_key_from_disk("test")
     attributes = EntityAttributes()
     with pytest.raises(EntityError):
         Entity(user_id, public_key, attributes)
@@ -42,19 +39,17 @@ def test_entity_constructor_bad_key():
         Entity(user_id, public_key, attributes)
 
 
-def test_entity_no_attributes():
+def test_entity_no_attributes(public_key):
     """Test the basic constructor."""
     user_id = "Hey It's Me"
-    public_key = get_public_key_from_disk("test")
     attributes = ["one", "two"]
     with pytest.raises(EntityError):
         Entity(user_id, public_key, attributes)
 
 
-def test_entity_constructor_with_attributes():
+def test_entity_constructor_with_attributes(public_key):
     """Test the basic constructor."""
     user_id = "Hey It's Me"
-    public_key = get_public_key_from_disk("test")
     attribute1 = (
         "https://aa.virtru.com/attr/unique-identifier"
         "/value/7b738968-131a-4de9-b4a1-c922f60583e3"
@@ -88,9 +83,7 @@ def test_entity_constructor_with_attributes():
     assert attr2.value == "7b738968-131a-4de9-b4a1-c922f60583e3"
 
 
-def make_eo():
-    public_key = get_public_key_from_disk("test")
-    private_key = get_private_key_from_disk("test")
+def make_eo(public_key, private_key):
     data = {
         "userId": "user@virtru.com",
         "aliases": [],
@@ -119,18 +112,16 @@ def make_eo():
     return data
 
 
-def test_load_from_raw_data_as_dict():
+def test_load_from_raw_data_as_dict(public_key, private_key):
     """Test load_from_raw_data.  Raw data as a dict."""
-    data = make_eo()
-    public_key = get_public_key_from_disk("test")
+    data = make_eo(public_key, private_key)
     actual = Entity.load_from_raw_data(data, public_key)
 
 
-def test_load_from_raw_data_raises_on_invalid_jwt():
+def test_load_from_raw_data_raises_on_invalid_jwt(public_key, private_key):
     """Test load_from_raw_data.  Raw data as a dict encoded as a jwt."""
-    data = make_eo()
+    data = make_eo(public_key, private_key)
     # invalidate the jwt in the 'cert' field.
     data["cert"] = data["cert"] + "aaaaaaa"
-    public_key = get_public_key_from_disk("test")
     with pytest.raises(tdf3_kas_core.errors.AuthorizationError):
-        actual = Entity.load_from_raw_data(data, public_key)
+        Entity.load_from_raw_data(data, public_key)

--- a/containers/kas/kas_core/tdf3_kas_core/models/wrapped_keys_test.py
+++ b/containers/kas/kas_core/tdf3_kas_core/models/wrapped_keys_test.py
@@ -21,14 +21,15 @@ from .wrapped_keys import (
     assure_public_key,
 )
 
-kas_public_key = get_public_key_from_disk("test")
-kas_private_key = get_private_key_from_disk("test")
-entity_public_key = get_public_key_from_disk("test_alt")
-entity_private_key = get_private_key_from_disk("test_alt")
-
 
 plain_key = b"This-is-the-good-key"
-wrapped_key = aes_encrypt_sha1(plain_key, kas_public_key)
+
+
+@pytest.fixture
+def wrapped_key(public_key):
+    return aes_encrypt_sha1(plain_key, public_key)
+
+
 good_msg = b"This message is valid"
 good_binding = str.encode(generate_hmac_digest(good_msg, plain_key))
 
@@ -50,15 +51,15 @@ def test_wrapped_key_from_plain():
     assert test_item._WrappedKey__unwrapped_key == plain_key
 
 
-def test_wrapped_key_from_raw():
+def test_wrapped_key_from_raw(wrapped_key, private_key):
     """Test the from raw factory function."""
     raw_wrapped_key = bytes.decode(base64.b64encode(wrapped_key))
-    test_item = WrappedKey.from_raw(raw_wrapped_key, kas_private_key)
+    test_item = WrappedKey.from_raw(raw_wrapped_key, private_key)
     assert isinstance(test_item, WrappedKey)
     assert test_item._WrappedKey__unwrapped_key == plain_key
 
 
-def test_rsa_sha1_keys():
+def test_rsa_sha1_keys(public_key, private_key):
     """Test asymmetric RSA SHA1 encrypt/decrypt."""
     expected = b"Cozy sphinx waves quart jug of bad milk"
     wrapped = aes_encrypt_sha1(expected, public_key)
@@ -66,7 +67,7 @@ def test_rsa_sha1_keys():
     assert actual == expected
 
 
-def test_wrapped_key_rewrap_key():
+def test_wrapped_key_rewrap_key(entity_public_key, entity_private_key):
     """Test the rewrap method."""
     test_item = WrappedKey(plain_key)
     rewrapped_b64str = test_item.rewrap_key(entity_public_key)
@@ -76,7 +77,7 @@ def test_wrapped_key_rewrap_key():
     assert actual == plain_key
 
 
-def test_wrapped_key_decrypt():
+def test_wrapped_key_decrypt(entity_public_key, entity_private_key):
     """Test the decrypt method."""
     test_item = WrappedKey(plain_key)
     rewrapped_b64str = test_item.rewrap_key(entity_public_key)
@@ -95,14 +96,11 @@ def test_aes_gcm_mode():
     assert actual == expected
 
 
-public_key = get_public_key_from_disk("test")
-private_key = get_private_key_from_disk("test")
-
 public_key_pem = get_public_key_from_disk("test", as_pem=True)
 private_key_pem = get_private_key_from_disk("test", as_pem=True)
 
 
-def test_assure_public_key_key():
+def test_assure_public_key_key(public_key):
     """Test assure_public_key passes through RSAPublicKeys."""
     actual = assure_public_key(public_key)
     assert actual == public_key
@@ -120,19 +118,19 @@ def test_assure_public_key_fail_str():
         assure_public_key("bad input")
 
 
-def test_assure_public_key_fail_private():
+def test_assure_public_key_fail_private(private_key):
     """Test assure_public_key raises error with private key."""
     with pytest.raises(CryptoError):
         assure_public_key(private_key)
 
 
-def test_assure_public_key_fail_private_pem():
+def test_assure_public_key_fail_private_pem(private_key):
     """Test assure_public_key raises error with private pem."""
     with pytest.raises(CryptoError):
-        assure_public_key(private_key_pem)
+        assure_public_key(private_key)
 
 
-def test_assure_private_key_key():
+def test_assure_private_key_key(private_key):
     """Test assure_private_key passes through RSAPrivateKeys."""
     actual = assure_private_key(private_key)
     assert actual == private_key
@@ -150,7 +148,7 @@ def test_assure_private_key_fail_bad_input():
         assure_private_key("bad input")
 
 
-def test_assure_private_key_fail_public():
+def test_assure_private_key_fail_public(public_key):
     """Test assure_private_key raises error on public key."""
     with pytest.raises(CryptoError):
         assure_private_key(public_key)

--- a/containers/kas/kas_core/tdf3_kas_core/services_test.py
+++ b/containers/kas/kas_core/tdf3_kas_core/services_test.py
@@ -17,9 +17,6 @@ from tdf3_kas_core.models import Claims
 
 from tdf3_kas_core.services import *
 
-from tdf3_kas_core.util import get_private_key_from_disk
-from tdf3_kas_core.util import get_public_key_from_disk
-
 
 KEYCLOAK_ACCESS_TOKEN = """eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI5a3VoOTdoakRXX2IyQkNmM243b1lTRXo5bUVaVGtmMllrMDRaR2dlN3lNIn0.eyJleHAiOjE2MTkxMTc1NzMsImlhdCI6MTYxOTExNzI3MywianRpIjoiYjJiZWQxMzktMDkzYy00NTFlLWJkNjUtY2JiNjI1ZDQ4NzBlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL2F1dGgvcmVhbG1zL3RkZiIsImF1ZCI6ImFjY291bnQiLCJzdWIiOiJiYTUxNjJjNC0wNmUxLTRjM2EtYTYwYy1jYTk1MjcyZjQ0ZTMiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJ0ZGYtY2xpZW50Iiwic2Vzc2lvbl9zdGF0ZSI6IjBkOGJmODA0LTQ1ZjktNDliNS05NzUyLWFjNzFlNjkzN2ZmNCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovL2xvY2FsaG9zdDo4MDgwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJlbWFpbCBwcm9maWxlIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJ2aXJ0cnVfZW50aXR5X29iamVjdCI6eyJhbGlhc2VzIjpbXSwiYXR0cmlidXRlcyI6W3sib2JqIjp7ImF0dHJpYnV0ZSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vYXR0ci9DbGFzc2lmaWNhdGlvbi92YWx1ZS9TIn19LHsib2JqIjp7ImF0dHJpYnV0ZSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vYXR0ci9DT0kvdmFsdWUvUFJYIn19XSwicHVibGljS2V5IjoiLS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS1cbk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBek1hQXJaN1VwV3VaMWt6aVVvT1NcblU1RmVmaXVxN2UyZUpIaWF0Z2RMNk9WeER3UjhDM09KTDMwR0JQN0JaWVIxYWczSkNlOW11TURnd2xIY1p1NDlcbmhManZJc2ZFcGQ5ZlpKdTExL3RocnljbXhBZ2p6OEdKcExCRnJBSHpPLzRwUVdNdkpXQkppOHlNVm9abnVMTE1cbmhNUnlLZ3ZFRUU3ZVVzcjNHT0RUMlZYUEoyYlJMOHZnTTJNcURFVnhycDFUZVBISEkza2VpeWVGVGM1aDA5RThcblFvZ3A3ME1YMVRkdURzZVRKNmR5V1o3TkwySmFPenZFNmFmSk1kZCtJSVRCMmpuRm4xejdFaDVOKy96TnB3cmJcbjFJK29ranpmS1hHL3MrYVVyNWFiMnZGRmlNbWhmWWlyMm9OckhwTXRFcFhnclFycmxoOUpxUE4xQzZST0FiZ3pcbnVRSURBUUFCXG4tLS0tLUVORCBQVUJMSUMgS0VZLS0tLS1cbiIsInNjaGVtYVZlcnNpb246IjoiMS4yLjMiLCJ1c2VySWQiOiJ1c2VyMUB2aXJ0cnUuY29tIn0sInByZWZlcnJlZF91c2VybmFtZSI6InVzZXIxIn0.NzhxhaV0z41Sz_f1ID5Fn3j7FmGZizTtZ0GbpX3AeE7tBFJpgMOWbcQdJ9F-OYXipP_Q7sutK0jpBaUEhy9HY-ozJfJqADjqDAFYzcUkmbNg4T_4PCOZL1Bv5w61Ftu0i7NYcXLGtRZaACTByVQyUTByDY7eOvWtMnEGZ9aC7o9iV2sMHp9W632EDmv-OlzDME3VTmmIazhdLYmMQG0lFtC_qf5dXwT0l8LhuoMCs8g3e_j6OKBOo0uaDrxZ584JD9amvcIZ6CjeWCfSFghlxVQFdrE7Dn5SmWnqdp682qWS3aBylfjgx8sdgX05YK93pE-MHUVhu12swWpkjh1oYA"""
 
@@ -150,14 +147,25 @@ def test_claims_object():
 
 
 class FakeKeyMaster:
+    def __init__(self, private_key) -> None:
+        self.private_key = private_key
+
     def get_key(self, name):
-        public_key = get_public_key_from_disk("test", as_pem=True)
-        private_key = get_private_key_from_disk("test", as_pem=True)
         if name == "KEYCLOAK-PUBLIC-tdf":
             return KEYCLOAK_PUBLIC_KEY
         elif name == "KAS-PRIVATE":
-            return private_key
-        raise Exception(f"Unknown test key: {name}")
+            return self.private_key
+        raise KeyNotFoundError(f"Unknown test key: {name}")
+
+
+@pytest.fixture
+def key_master(private_key):
+    return FakeKeyMaster(private_key)
+
+
+@pytest.fixture
+def key_master(private_key):
+    return FakeKeyMaster(private_key)
 
 
 def test_kas_public_rsa_key():
@@ -191,7 +199,9 @@ def test_ping():
 @patch(
     "tdf3_kas_core.models.Claims.load_from_raw_data", return_value=test_claims_object()
 )
-def test_rewrap_v2(entity_load_mock, tdf3_mock, nano_mock, jwt_mock, with_idp):
+def test_rewrap_v2(
+    entity_load_mock, tdf3_mock, nano_mock, jwt_mock, with_idp, key_master
+):
     """Test the rewrap_v2 service."""
     os.environ["OIDC_SERVER_URL"] = "https://keycloak.dev"
     expected_uuid = "1111-2222-33333-44444-abddef-timestamp"
@@ -223,7 +233,6 @@ def test_rewrap_v2(entity_load_mock, tdf3_mock, nano_mock, jwt_mock, with_idp):
     context = Context()
     context.add("Authorization", f"Bearer {KEYCLOAK_ACCESS_TOKEN}")
     plugin_runner = MagicMock()
-    key_master = FakeKeyMaster()
     rewrap_v2(request_data, context, plugin_runner, key_master)
     assert True
 
@@ -233,7 +242,9 @@ def test_rewrap_v2(entity_load_mock, tdf3_mock, nano_mock, jwt_mock, with_idp):
 @patch(
     "tdf3_kas_core.models.Claims.load_from_raw_data", return_value=test_claims_object
 )
-def test_rewrap_v2_expired_token(entity_load_mock, tdf3_mock, nano_mock, with_idp):
+def test_rewrap_v2_expired_token(
+    entity_load_mock, tdf3_mock, nano_mock, with_idp, key_master
+):
     expected_uuid = "1111-2222-33333-44444-abddef-timestamp"
     expected_canonical = "This is a canonical string"
     attributes = [
@@ -258,7 +269,6 @@ def test_rewrap_v2_expired_token(entity_load_mock, tdf3_mock, nano_mock, with_id
     context = Context()
     context.add("Authorization", f"Bearer {KEYCLOAK_ACCESS_TOKEN}")
     plugin_runner = MagicMock()
-    key_master = FakeKeyMaster()
 
     signedToken = jwt.encode(data, CLIENT_SIGNING_PRIVATE_KEY, "RS256")
     request_data = {"signedRequestToken": signedToken}
@@ -275,7 +285,9 @@ def test_rewrap_v2_expired_token(entity_load_mock, tdf3_mock, nano_mock, with_id
 @patch(
     "tdf3_kas_core.models.Claims.load_from_raw_data", return_value=test_claims_object
 )
-def test_rewrap_v2_no_auth_header(entity_load_mock, tdf3_mock, nano_mock, with_idp):
+def test_rewrap_v2_no_auth_header(
+    entity_load_mock, tdf3_mock, nano_mock, with_idp, key_master
+):
     expected_uuid = "1111-2222-33333-44444-abddef-timestamp"
     expected_canonical = "This is a canonical string"
     attributes = [
@@ -303,7 +315,6 @@ def test_rewrap_v2_no_auth_header(entity_load_mock, tdf3_mock, nano_mock, with_i
     context = Context()
     # Skip context.add("Authorization", ...)
     plugin_runner = MagicMock()
-    key_master = FakeKeyMaster()
     # This token is expired, should fail.
     # Actual exception is:  jwt.exceptions.ExpiredSignatureError
     with pytest.raises(tdf3_kas_core.errors.UnauthorizedError):
@@ -317,7 +328,7 @@ def test_rewrap_v2_no_auth_header(entity_load_mock, tdf3_mock, nano_mock, with_i
     "tdf3_kas_core.models.Claims.load_from_raw_data", return_value=test_claims_object
 )
 def test_rewrap_v2_invalid_auth_header(
-    entity_load_mock, tdf3_mock, nano_mock, with_idp
+    entity_load_mock, tdf3_mock, nano_mock, with_idp, key_master
 ):
     expected_uuid = "1111-2222-33333-44444-abddef-timestamp"
     expected_canonical = "This is a canonical string"
@@ -347,7 +358,6 @@ def test_rewrap_v2_invalid_auth_header(
     context = Context()
     context.add("Authorization", f"Chair-er Token:{KEYCLOAK_ACCESS_TOKEN}")
     plugin_runner = MagicMock()
-    key_master = FakeKeyMaster()
     # This token is expired, should fail.
     # Actual exception is:  jwt.exceptions.ExpiredSignatureError
     with pytest.raises(tdf3_kas_core.errors.UnauthorizedError):
@@ -360,7 +370,9 @@ def test_rewrap_v2_invalid_auth_header(
 @patch(
     "tdf3_kas_core.models.Claims.load_from_raw_data", return_value=test_claims_object
 )
-def test_rewrap_v2_invalid_auth_jwt(entity_load_mock, tdf3_mock, nano_mock, with_idp):
+def test_rewrap_v2_invalid_auth_jwt(
+    entity_load_mock, tdf3_mock, nano_mock, with_idp, key_master
+):
     expected_uuid = "1111-2222-33333-44444-abddef-timestamp"
     expected_canonical = "This is a canonical string"
     attributes = [
@@ -386,7 +398,6 @@ def test_rewrap_v2_invalid_auth_jwt(entity_load_mock, tdf3_mock, nano_mock, with
     context = Context()
     context.add("Authorization", "Bearer DO I LOOK LIKE A JWT TO YOU?")
     plugin_runner = MagicMock()
-    key_master = FakeKeyMaster()
 
     signedToken = jwt.encode(data, CLIENT_SIGNING_PRIVATE_KEY, "RS256")
     request_data = {"signedRequestToken": signedToken}
@@ -403,10 +414,8 @@ def test_rewrap_v2_invalid_auth_jwt(entity_load_mock, tdf3_mock, nano_mock, with
 @patch(
     "tdf3_kas_core.models.Claims.load_from_raw_data", return_value=test_claims_object()
 )
-def test_upsert_v2(entity_load_mock, jwt_mock, ka_mock):
+def test_upsert_v2(entity_load_mock, jwt_mock, ka_mock, key_master):
     """Test the upsert_v2 service."""
-    expected_uuid = "1111-2222-33333-44444-abddef-timestamp"
-    expected_canonical = "This is a canonical string"
     attributes = [
         {"attribute": "https://example.com/attr/Classification/value/S"},
         {"attribute": "https://example.com/attr/COI/value/PRX"},
@@ -447,7 +456,6 @@ def test_upsert_v2(entity_load_mock, jwt_mock, ka_mock):
     context = Context()
     context.add("Authorization", f"Bearer {KEYCLOAK_ACCESS_TOKEN}")
     plugin_runner = MagicMock()
-    key_master = FakeKeyMaster()
     upsert_v2(request_data, context, plugin_runner, key_master)
     assert True
 
@@ -457,10 +465,10 @@ def test_upsert_v2(entity_load_mock, jwt_mock, ka_mock):
 @patch(
     "tdf3_kas_core.models.Claims.load_from_raw_data", return_value=test_claims_object()
 )
-def test_upsert_v2_no_auth_header(entity_load_mock, jwt_mock, ka_mock, with_idp):
+def test_upsert_v2_no_auth_header(
+    entity_load_mock, jwt_mock, ka_mock, with_idp, key_master
+):
     """Test the upsert_v2 service."""
-    expected_uuid = "1111-2222-33333-44444-abddef-timestamp"
-    expected_canonical = "This is a canonical string"
     attributes = [
         {"attribute": "https://example.com/attr/Classification/value/S"},
         {"attribute": "https://example.com/attr/COI/value/PRX"},
@@ -501,7 +509,6 @@ def test_upsert_v2_no_auth_header(entity_load_mock, jwt_mock, ka_mock, with_idp)
     context = Context()
     # context.add("Authorization", "Bearer {0}".format(KEYCLOAK_ACCESS_TOKEN))
     plugin_runner = MagicMock()
-    key_master = FakeKeyMaster()
     with pytest.raises(tdf3_kas_core.errors.UnauthorizedError):
         upsert_v2(request_data, context, plugin_runner, key_master)
     assert True
@@ -512,10 +519,10 @@ def test_upsert_v2_no_auth_header(entity_load_mock, jwt_mock, ka_mock, with_idp)
 @patch(
     "tdf3_kas_core.models.Claims.load_from_raw_data", return_value=test_claims_object()
 )
-def test_upsert_v2_invalid_auth_header(entity_load_mock, jwt_mock, ka_mock, with_idp):
+def test_upsert_v2_invalid_auth_header(
+    entity_load_mock, jwt_mock, ka_mock, with_idp, key_master
+):
     """Test the upsert_v2 service."""
-    expected_uuid = "1111-2222-33333-44444-abddef-timestamp"
-    expected_canonical = "This is a canonical string"
     attributes = [
         {"attribute": "https://example.com/attr/Classification/value/S"},
         {"attribute": "https://example.com/attr/COI/value/PRX"},
@@ -556,7 +563,6 @@ def test_upsert_v2_invalid_auth_header(entity_load_mock, jwt_mock, ka_mock, with
     context = Context()
     context.add("Authorization", f"Terr-or Token {KEYCLOAK_ACCESS_TOKEN}")
     plugin_runner = MagicMock()
-    key_master = FakeKeyMaster()
     with pytest.raises(tdf3_kas_core.errors.UnauthorizedError):
         upsert_v2(request_data, context, plugin_runner, key_master)
     assert True
@@ -567,10 +573,10 @@ def test_upsert_v2_invalid_auth_header(entity_load_mock, jwt_mock, ka_mock, with
 @patch(
     "tdf3_kas_core.models.Claims.load_from_raw_data", return_value=test_claims_object()
 )
-def test_upsert_v2_invalid_auth_jwt(entity_load_mock, jwt_mock, ka_mock, with_idp):
+def test_upsert_v2_invalid_auth_jwt(
+    entity_load_mock, jwt_mock, ka_mock, with_idp, key_master
+):
     """Test the upsert_v2 service."""
-    expected_uuid = "1111-2222-33333-44444-abddef-timestamp"
-    expected_canonical = "This is a canonical string"
     attributes = [
         {"attribute": "https://example.com/attr/Classification/value/S"},
         {"attribute": "https://example.com/attr/COI/value/PRX"},
@@ -612,7 +618,6 @@ def test_upsert_v2_invalid_auth_jwt(entity_load_mock, jwt_mock, ka_mock, with_id
     context = Context()
     context.add("Authorization", "Bearer DO I LOOK LIKE A JWT TO YOU?")
     plugin_runner = MagicMock()
-    key_master = FakeKeyMaster()
     with pytest.raises(tdf3_kas_core.errors.UnauthorizedError):
         upsert_v2(request_data, context, plugin_runner, key_master)
     assert True


### PR DESCRIPTION
I'd like to remove these helper functions, which include some test-only code. `pytest` fixtures are a better way of loading test items than from disk. 

This is the first step in removing them - a mostly mechanical refactor that replaces their usage in test code with the equivalent pytest inject call. While I'm here, this also removes a few bits of dead code


### Proposed Changes

- Introduces some global fixtures to replace loading 'test' keys all over the place in our tests
- Replaces most of the calls to load this test code that are easy to refactor. Some harder ones to extract will follow but I want to avoid bloating this PR
- Remove some unused variables in test that pylance disapproves of

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
