### PR TITLE
Set default org id for audit

### DIFF
--- a/charts/attributes/templates/configmap.yaml
+++ b/charts/attributes/templates/configmap.yaml
@@ -26,4 +26,4 @@ data:
   SERVER_PUBLIC_NAME: {{ .Values.serverPublicName | quote  }}
   SERVER_ROOT_PATH: {{ .Values.serverRootPath | quote  }}
   SERVER_CORS_ORIGINS: {{ .Values.serverCorsOrigins | quote  }}
-  AUDIT_ORG_ID: {{ .Values.global.opentdf.common.auditOrgId | quote }}
+  AUDIT_ORG_ID: {{ .Values.global.opentdf.common.auditOrgId | default "00000000-0000-0000-0000-000000000000" | quote }}

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -32,7 +32,7 @@ global:
       # -- Enable audit logging
       auditLogEnabled: false
       # -- Audit Org Id
-      auditOrgId:
+      auditOrgId: ""
       istio:
         # -- Enable istio ingress
         enabled: false

--- a/charts/entitlements/templates/configmap.yaml
+++ b/charts/entitlements/templates/configmap.yaml
@@ -26,4 +26,4 @@ data:
   SERVER_PUBLIC_NAME: {{ .Values.serverPublicName | quote }}
   SERVER_ROOT_PATH: {{ .Values.serverRootPath | quote }}
   SERVER_CORS_ORIGINS: {{ .Values.serverCorsOrigins | quote  }}
-  AUDIT_ORG_ID: {{ .Values.global.opentdf.common.auditOrgId | quote }}
+  AUDIT_ORG_ID: {{ .Values.global.opentdf.common.auditOrgId | default "00000000-0000-0000-0000-000000000000" | quote }}

--- a/charts/kas/templates/configmap.yaml
+++ b/charts/kas/templates/configmap.yaml
@@ -22,4 +22,4 @@ data:
   AUDIT_ENABLED: {{ .Values.global.opentdf.common.auditLogEnabled | quote  }}
   SWAGGER_UI: {{ .Values.swaggerUIEnabled | quote }}
   USE_OIDC: "1"
-  AUDIT_ORG_ID: {{ .Values.global.opentdf.common.auditOrgId | quote }}
+  AUDIT_ORG_ID: {{ .Values.global.opentdf.common.auditOrgId | default "00000000-0000-0000-0000-000000000000" | quote }}


### PR DESCRIPTION
### Proposed Changes
fixes https://github.com/opentdf/tests/actions/runs/6411696405
default to 0s uuid -- we don't use orgIds


### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
