### PR TITLE
🔥 Remove old name for attr auth

### DIFF
--- a/containers/kas/kas_app/tdf3_kas_app/config/attribute-config.json
+++ b/containers/kas/kas_app/tdf3_kas_app/config/attribute-config.json
@@ -1,6 +1,6 @@
 {
   "https://eas.virtru.com/attr/ClassificationUS": {
-    "authorityNamespace": "https://eas.virtru.com",
+    "authority": "https://eas.virtru.com",
     "name": "ClassificationUS",
     "order": [
       "TopSecret",
@@ -12,7 +12,7 @@
     "state": "active"
   },
   "https://eas.virtru.com/attr/ClassificationNATO": {
-    "authorityNamespace": "https://eas.virtru.com",
+    "authority": "https://eas.virtru.com",
     "name": "ClassificationNATO",
     "order": [
         "COSMICTopSecret",
@@ -24,7 +24,7 @@
       "state": "active"
     },
   "https://eas.virtru.com/attr/SCIControls": {
-    "authorityNamespace": "https://eas.virtru.com",
+    "authority": "https://eas.virtru.com",
     "name": "SCIControls",
     "order": [
         "SI",
@@ -36,7 +36,7 @@
       "state": "active"
     },
   "https://eas.virtru.com/attr/SensorNTK": {
-    "authorityNamespace": "https://eas.virtru.com",
+    "authority": "https://eas.virtru.com",
     "name": "SensorNTK",
     "order": [
         "UAV-Imagery",
@@ -49,7 +49,7 @@
       "state": "active"
     },
   "https://eas.virtru.com/attr/Mission": {
-    "authorityNamespace": "https://eas.virtru.com",
+    "authority": "https://eas.virtru.com",
     "name": "Mission",
     "order": [
         "OBJ-MEL",

--- a/containers/kas/kas_app/tdf3_kas_app/plugins/opentdf_attr_authority_plugin.py
+++ b/containers/kas/kas_app/tdf3_kas_app/plugins/opentdf_attr_authority_plugin.py
@@ -17,29 +17,6 @@ from tdf3_kas_core.errors import (
 logger = logging.getLogger(__name__)
 
 
-def _translate_otdf_attrdefs(attrdefs):
-    """
-    KAS has an (undocumented) format for attribute definitions
-    that differs from the one OpenTDF uses by two (2) property names
-    so just append those duplicate properties to the dict and
-    call it a day - the schema emitted by the AA shouldn't be
-    tightly coupled to KAS processing and it's not worth maintaining
-    separate serverside handlers for this.
-
-    You might ask why this plugin/kas data model isn't just changed to use the
-    new route/handler.
-
-    Well, that's because the new handler does non-optional pagination and JWT auth,
-    and KAS isn't set up to do the former, and doesn't need to do the latter (E-W traffic)
-    """
-
-    for attr in attrdefs:
-        if "authority" in attr:
-            attr["authorityNamespace"] = attr["authority"]
-        if "order" in attr:
-            attr["values"] = attr["order"]
-
-
 class OpenTDFAttrAuthorityPlugin(AbstractHealthzPlugin, AbstractRewrapPlugin):
     """Fetch attributes from OpenTDF Attribute authority instance.
     Note that this plugin is expected to return a list of attributes
@@ -47,7 +24,7 @@ class OpenTDFAttrAuthorityPlugin(AbstractHealthzPlugin, AbstractRewrapPlugin):
 
 
      class Attribute:
-         authorityNamespace: AnyUrl
+         authority: AnyUrl
          name: str
          order: list
          rule: RuleEnum
@@ -130,7 +107,6 @@ class OpenTDFAttrAuthorityPlugin(AbstractHealthzPlugin, AbstractRewrapPlugin):
         )
         for namespace in namespaces:
             ns_attrdefs = self._fetch_definition_from_authority_by_ns(namespace)
-            _translate_otdf_attrdefs(ns_attrdefs)
             attrs = attrs + ns_attrdefs
 
         if len(attrs) == 0:

--- a/containers/kas/kas_app/tdf3_kas_app/plugins/opentdf_attr_authority_plugin_test.py
+++ b/containers/kas/kas_app/tdf3_kas_app/plugins/opentdf_attr_authority_plugin_test.py
@@ -78,8 +78,8 @@ def test_fetch_attributes_200_status(mock_request):
     actual = OpenTDFAttrAuthorityPlugin(HOST)
     attributes = actual.fetch_attributes(NAMESPACES)
     assert len(attributes) == 4
-    assert "authorityNamespace" in attributes[0]
-    assert "authorityNamespace" in attributes[1]
+    assert "authority" in attributes[0]
+    assert "authority" in attributes[1]
 
 
 @patch.object(requests, "get", side_effect=requests.exceptions.ReadTimeout)

--- a/containers/kas/kas_core/scripts/test.env
+++ b/containers/kas/kas_core/scripts/test.env
@@ -1,22 +1,26 @@
 #!/usr/bin/env bash
 
-if ! go install github.com/virtru/access-pdp@v1.7.0; then
-  echo "Unable to install access-pdp"
-  exit 1
-fi
+if pgrep access-pdp; then
+  echo "access-pdp is already running"
+else
+  if ! go install github.com/virtru/access-pdp@v1.7.0; then
+    echo "Unable to install access-pdp"
+    exit 1
+  fi
 
-f=${GOBIN:-${GOPATH:-~/go}/bin}
-if [ ! -f "${f}/access-pdp" ]; then
-  echo "Can't find access-pdp, not in [${f}]"
-  exit 1
-fi
+  f=${GOBIN:-${GOPATH:-~/go}/bin}
+  if [ ! -f "${f}/access-pdp" ]; then
+    echo "Can't find access-pdp, not in [${f}]"
+    exit 1
+  fi
 
-"${f}/access-pdp" &
-aphid=$!
+  "${f}/access-pdp" &
+  aphid=$!
 
-sleep 5
+  sleep 5
 
-if ! ps -p "${aphid}" > /dev/null; then
-  echo "access-pdp stopped or failed to run"
-  exit 1
+  if ! ps -p "${aphid}" > /dev/null; then
+    echo "access-pdp stopped or failed to run"
+    exit 1
+  fi
 fi

--- a/containers/kas/kas_core/tdf3_kas_core/abstractions.py
+++ b/containers/kas/kas_core/tdf3_kas_core/abstractions.py
@@ -71,7 +71,7 @@ class AbstractRewrapPlugin(AbstractPlugin):
         objects like the following:
 
          class Attribute:
-             authorityNamespace: AnyUrl
+             authority: AnyUrl
              name: str
              order: list
              rule: RuleEnum

--- a/containers/kas/kas_core/tdf3_kas_core/models/adjudicator/adjudicator_test.py
+++ b/containers/kas/kas_core/tdf3_kas_core/models/adjudicator/adjudicator_test.py
@@ -85,9 +85,7 @@ def test_adjudicator_denies_access_from_dissem(public_key):
 
 # >>>>>>>>>> ALL OF <<<<<<<<<<<<<<<<<<
 
-all_of_config = [
-    {"authorityNamespace": "https://example.com", "name": "NTK", "rule": "allOf"}
-]
+all_of_config = [{"authority": "https://example.com", "name": "NTK", "rule": "allOf"}]
 
 
 def test_adjudicator_grants_access_allof_attribute(public_key):
@@ -134,9 +132,7 @@ def test_adjudicator_denies_access_allof_attribute(public_key):
 
 # >>>>>>>>>> ANY OF <<<<<<<<<<<<<<<<<<
 
-any_of_config = [
-    {"authorityNamespace": "https://example.com", "name": "Rel", "rule": "anyOf"}
-]
+any_of_config = [{"authority": "https://example.com", "name": "Rel", "rule": "anyOf"}]
 
 
 def test_adjudicator_grants_access_anyof_attribute(public_key):
@@ -189,7 +185,7 @@ def test_adjudicator_denies_access_anyof_attribute(public_key):
 
 hierarchy_config = [
     {
-        "authorityNamespace": "https://example.com",
+        "authority": "https://example.com",
         "name": "classif",
         "order": ["TS", "S", "C", "U"],
         "rule": "hierarchy",

--- a/containers/kas/kas_core/tdf3_kas_core/models/attribute_policies/attribute_policy_cache.py
+++ b/containers/kas/kas_core/tdf3_kas_core/models/attribute_policies/attribute_policy_cache.py
@@ -36,7 +36,7 @@ class AttributePolicyCache(object):
         )
         for attribute_object in attribute_policy_config:
             # use the policy constructor to validate the inputs
-            authority_namespace = attribute_object["authorityNamespace"]
+            authority_namespace = attribute_object["authority"]
             attribute_name = attribute_object["name"]
             attribute_name_object = f"{authority_namespace}/attr/{attribute_name}"
             if "rule" in attribute_object:

--- a/containers/kas/kas_core/tdf3_kas_core/models/attribute_policies/attribute_policy_cache_test.py
+++ b/containers/kas/kas_core/tdf3_kas_core/models/attribute_policies/attribute_policy_cache_test.py
@@ -32,9 +32,9 @@ def test_attribute_policy_cache_get_with_default_create():
 def test_attribute_policy_cache_load_config():
     """Test config loader."""
     test_config_json = """[
-{"authorityNamespace": "https://example.com", "name": "NTK", "rule": "allOf"},
-{"authorityNamespace": "https://example.com", "name": "Rel", "rule": "anyOf"},
-{"authorityNamespace": "https://example.com", "name": "Classification", "order": ["TS", "S", "C", "U"], "rule": "hierarchy"}
+{"authority": "https://example.com", "name": "NTK", "rule": "allOf"},
+{"authority": "https://example.com", "name": "Rel", "rule": "anyOf"},
+{"authority": "https://example.com", "name": "Classification", "order": ["TS", "S", "C", "U"], "rule": "hierarchy"}
     ]"""
     test_config = json.loads(test_config_json)
 

--- a/containers/kas/kas_core/tdf3_kas_core/pdp_grpc.py
+++ b/containers/kas/kas_core/tdf3_kas_core/pdp_grpc.py
@@ -26,7 +26,7 @@ def convert_attribute_defs(attribute_defs):
     pb_attr_defs = []
     for attribute_def in attribute_defs:
         # use the policy constructor to validate the inputs
-        authority = attribute_def["authorityNamespace"]
+        authority = attribute_def["authority"]
         name = attribute_def["name"]
 
         # TODO This is an existing KAS default - if no definition (or incomplete definition)

--- a/tests/e2e-test/run_test.py
+++ b/tests/e2e-test/run_test.py
@@ -26,7 +26,7 @@ def test_setup():
     response = requests.post(
         f"{attribute_authority_host}/v1/attr",
         json={
-            "authorityNamespace": "https://eas.local",
+            "authority": "https://eas.local",
             "name": "language",
             "rule": "anyOf",
             "state": "published",


### PR DESCRIPTION
### Proposed Changes

- Remove unnecessary name translation logic
- May cause some effects downstream but I don't see how
- While here, do some more test cleanup
  - don't start access-pdp if already running
  - remove some magic mock usage

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
