### PR TITLE
🔧 Lets trustedEntitlers be a prefix check

### DIFF
--- a/containers/kas/kas_core/tdf3_kas_core/kas.py
+++ b/containers/kas/kas_core/tdf3_kas_core/kas.py
@@ -2,9 +2,9 @@
 
 import os
 import connexion
-
 import importlib_resources
 import logging
+import urllib.parse
 
 from . import services
 
@@ -31,6 +31,26 @@ from .util.swagger_ui_bundle import swagger_ui_4_path
 from .util.hooks import hook_into, post_rewrap_v2_hook_default
 
 logger = logging.getLogger(__name__)
+
+
+def clean_trusted_url(u):
+    r = urllib.parse.urlparse(u, scheme="https")
+    if r.fragment:
+        logger.warning(
+            "Fragments in trusted entitlement URIs are ignored: [%s] won't be required",
+            r.fragment,
+        )
+    if r.query:
+        logger.warning(
+            "Be careful. We use prefix matching for trusted entitlers, so query params are unusual [%s]",
+            u,
+        )
+        if r.path:
+            return f"{r.scheme}://{r.netloc}{r.path}?{r.query}"
+        return f"{r.scheme}://{r.netloc}/?{r.query}"
+    if not r.path:
+        return f"{r.scheme}://{r.netloc}/"
+    return f"{r.scheme}://{r.netloc}{r.path}"
 
 
 def create_session_ping(version):
@@ -182,7 +202,7 @@ class Kas(object):
         self._root_name = name
 
     def set_trusted_entitlers(self, trusted_entitlers):
-        self._trusted_entitlers = trusted_entitlers
+        self._trusted_entitlers = [clean_trusted_url(e) for e in trusted_entitlers]
 
     def set_version(self, version=None):
         """Set version for the heartbeat message."""

--- a/containers/kas/kas_core/tdf3_kas_core/kas_test.py
+++ b/containers/kas/kas_core/tdf3_kas_core/kas_test.py
@@ -1,9 +1,7 @@
 """Test the KAS core code."""
 
 
-
-
-from .kas import Kas, swagger_enabled
+from .kas import Kas, clean_trusted_url, swagger_enabled
 
 name = "__main__"
 
@@ -51,3 +49,13 @@ def test_kas_constructor():
 
 def test_swagger_disabled_default():
     assert not swagger_enabled()
+
+
+def test_clean_trusted_url():
+    assert "https://a/" == clean_trusted_url("//a")
+    assert "https://a/" == clean_trusted_url("https://a/")
+    assert "https://a/" == clean_trusted_url("https://a#ignored")
+    assert "http://a/" == clean_trusted_url("http://a")
+    assert "https://a/?alpha=beta" == clean_trusted_url("https://a?alpha=beta")
+    assert "https://a/b" == clean_trusted_url("https://a/b")
+    assert "https://a/b?a=b" == clean_trusted_url("https://a/b?a=b")

--- a/containers/kas/kas_core/tdf3_kas_core/services.py
+++ b/containers/kas/kas_core/tdf3_kas_core/services.py
@@ -276,13 +276,12 @@ def _fetch_distributed_claims(names, sources, claim_name, allowlist):
         )
         raise UnauthorizedError("broken distributed claim link")
     endpoint = source["endpoint"]
-    if endpoint not in allowlist:
-        logger.warning(
-            "unrecognized or disallowed claim source [%s] -> [%s] ∉ %s",
-            source_name,
-            endpoint,
-            allowlist,
-        )
+    matched = False
+    for trusted_entitler in allowlist:
+        if endpoint.startswith(trusted_entitler):
+            matched = True
+            break
+    if not matched:
         raise UnauthorizedError("unrecognized or disallowed claim source")
 
     if not endpoint.startswith("https://"):


### PR DESCRIPTION
It does require a trailing slash after the host, so this should be sufficient for preventing prefix name attacks


### Proposed Changes


### Checklist

- [x] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
