### PR TITLE
✨ Adds ISSUER_URL for simple OIDC support in KAS

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -43,7 +43,10 @@ backend(
         + server_root.items()
         + cors_origins.items()
         + [
-            ('kas.auth."http://localhost:65432/auth/realms/tdf".clientId', "tdf-access")
+            (
+                "kas.auth.http://localhost:65432/auth/realms/tdf.discoveryBaseUrl",
+                "http://keycloak-http/auth/realms/tdf",
+            )
         ],
     ),
 )

--- a/Tiltfile
+++ b/Tiltfile
@@ -42,5 +42,8 @@ backend(
         + openapi_enable.items()
         + server_root.items()
         + cors_origins.items()
-    )
+        + [
+            ('kas.auth."http://localhost:65432/auth/realms/tdf".clientId', "tdf-access")
+        ],
+    ),
 )

--- a/charts/kas/templates/configmap.yaml
+++ b/charts/kas/templates/configmap.yaml
@@ -16,11 +16,6 @@ data:
   {{- with .Values.endpoints.trustedEntitlers | join " " }}
   TRUSTED_ENTITLERS: {{ . }}
   {{- end }}
-  {{- with include "kas.oidcPubkeyEndpoint" . }}
-
-  # Old Keycloak 'all realms' configuration
-  OIDC_SERVER_URL: {{ . | quote }}
-  {{- end }}
   {{- with .Values.auth }}
   {{-   $length := len . }}
   {{-   if eq $length 1 }}
@@ -34,6 +29,12 @@ data:
   {{-     end }}
   {{-   else }}
   {{-     fail "TODO: Support multiple realms for auth" }}
+  {{-   end }}
+  {{- else }}
+  {{-   with include "kas.oidcPubkeyEndpoint" . }}
+
+  # Old Keycloak 'all realms' configuration
+  OIDC_SERVER_URL: {{ . | quote }}
   {{-   end }}
   {{- end }}
 

--- a/charts/kas/templates/configmap.yaml
+++ b/charts/kas/templates/configmap.yaml
@@ -9,20 +9,44 @@ data:
   {{- with (coalesce .Values.endpoints.attrHost .Values.endpoints.easHost) }}
   ATTR_AUTHORITY_HOST: {{ tpl . $ | quote  }}
   {{- end }}
-  FLASK_DEBUG: {{ .Values.flaskDebug | quote }}
   GUNICORN_WORKERS: {{ .Values.gunicornWorkers | default 1 | quote }}
-  OIDC_SERVER_URL: {{ include "kas.oidcPubkeyEndpoint" . | quote }}
+
+  USE_OIDC: "1"
+  AUDIT_ORG_ID: {{ .Values.global.opentdf.common.auditOrgId | default "00000000-0000-0000-0000-000000000000" | quote }}
+  {{- with .Values.endpoints.trustedEntitlers | join " " }}
+  TRUSTED_ENTITLERS: {{ . }}
+  {{- end }}
+  {{- with include "kas.oidcPubkeyEndpoint" . }}
+
+  # Old Keycloak 'all realms' configuration
+  OIDC_SERVER_URL: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.auth }}
+  {{-   $length := len . }}
+  {{-   if eq $length 1 }}
+  {{-     range $issuer, $details := . }}
+
+  # Single realm, no keycloak integration feature
+  OIDC_ISSUER_URL: {{ $issuer | quote }}
+  {{-       with $details.discoveryBaseUrl }}
+  OIDC_DISCOVERY_BASE_URL: {{ . | quote}}
+  {{-       end }}
+  {{-     end }}
+  {{-   else }}
+  {{-     fail "TODO: Support multiple realms for auth" }}
+  {{-   end }}
+  {{- end }}
+
+  # Logging and tracing configuration
   LOGLEVEL: {{ .Values.logLevel | quote }}
   VERBOSE: {{ .Values.pdp.verbose | quote }}
   {{- with .Values.endpoints.statsdHost }}
   STATSD_HOST: {{ tpl . $ | quote  }}
   {{- end }}
   DISABLE_TRACING: {{ .Values.pdp.disableTracing | quote }}
+  FLASK_DEBUG: {{ .Values.flaskDebug | quote }}
   JSON_LOGGER: {{ .Values.jsonLogger | default "true" | quote }}
   AUDIT_ENABLED: {{ .Values.global.opentdf.common.auditLogEnabled | quote  }}
+
+  # OpenAPI test user interface
   SWAGGER_UI: {{ .Values.swaggerUIEnabled | quote }}
-  USE_OIDC: "1"
-  AUDIT_ORG_ID: {{ .Values.global.opentdf.common.auditOrgId | default "00000000-0000-0000-0000-000000000000" | quote }}
-  {{- with .Values.endpoints.trustedEntitlers | join " " }}
-  TRUSTED_ENTITLERS: {{ . }}
-  {{- end }}

--- a/charts/kas/values.yaml
+++ b/charts/kas/values.yaml
@@ -184,6 +184,14 @@ endpoints:
   # -- Local override for `global.opentdf.common.oidcInternalBaseUrl` + path
   oidcPubkeyEndpoint:
 
+# --Configuration of supported auth services, if present
+auth: {}
+# the service URL, e.g. "https://localhost:65432/auth/realms/tdf"
+# [issuer]:
+# --Discovery url; used to find well-known configuration by service.
+#   clientId: tdf-access
+#   discoveryBaseUrl: "http://keycloak-http/auth/realms/tdf"
+
 # -- Adds a container `livenessProbe`, if set.
 livenessProbe:
   httpGet:

--- a/common.Tiltfile
+++ b/common.Tiltfile
@@ -66,7 +66,9 @@ def dict_to_helm_set_list(dict):
 # values: list of values files
 # set: dictionary of value_name: value pairs
 # extra_helm_parameters: only valid when devmode=False; passed to underlying `helm update` command
-def backend(values=[], set={}, extra_helm_parameters=[], devmode=False):
+def backend(
+    values=[], set={}, external_port="65432", extra_helm_parameters=[], devmode=False
+):
     #   o8o
     #   `"'
     #  oooo  ooo. .oo.  .oo.    .oooo.    .oooooooo  .ooooo.   .oooo.o
@@ -186,7 +188,9 @@ def backend(values=[], set={}, extra_helm_parameters=[], devmode=False):
         version="4.0.16",
     )
 
-    k8s_resource("ingress-nginx-controller", port_forwards="65432:80")
+    k8s_resource(
+        "ingress-nginx-controller", port_forwards="{}:80".format(external_port)
+    )
 
     # TODO not sure why this needs to be installed separately, but
     # our ingress config won't work without it.

--- a/containers/kas/kas_app/tdf3_kas_app/kas_app.py
+++ b/containers/kas/kas_app/tdf3_kas_app/kas_app.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 USE_OIDC = os.environ.get("USE_OIDC") == "1"
 OIDC_SERVER_URL = os.environ.get("OIDC_SERVER_URL") is not None
+OIDC_ISSUER_URL = os.environ.get("OIDC_ISSUER_URL") is not None
 
 AUDIT_ENABLED = os.getenv("AUDIT_ENABLED", "false").lower() in ("yes", "true", "t", "1")
 TRUSTED_ENTITLERS = os.environ.get("TRUSTED_ENTITLERS", "").split()
@@ -86,10 +87,12 @@ def app(name):
 
     if USE_OIDC and OIDC_SERVER_URL:
         logger.info("Keycloak integration enabled.")
-    elif USE_OIDC or OIDC_SERVER_URL:
-        e_msg = "Either USE_OIDC or OIDC_SERVER_URL are not correctly defined - both are required."
-        logger.error(e_msg)
-        raise Exception(e_msg)
+    elif USE_OIDC and OIDC_ISSUER_URL:
+        logger.info("Single OAuth2 integration enabled.")
+    elif USE_OIDC or OIDC_SERVER_URL or OIDC_ISSUER_URL:
+        raise Exception(
+            "Either USE_OIDC or one of OIDC_SERVER_URL and OIDC_ISSUER_URL are not correctly defined"
+        )
     # Add Attribute fetch plugin
     attr_host = os.environ.get("ATTR_AUTHORITY_HOST")
     if not attr_host:

--- a/containers/kas/kas_core/tdf3_kas_core/authorized.py
+++ b/containers/kas/kas_core/tdf3_kas_core/authorized.py
@@ -123,6 +123,7 @@ def oidc_discovery(server: str) -> dict:
 def jwt_verifier_key(
     issuer: str, discovery_base: str | None, idpJWT: str | bytes
 ) -> PublicKeyTypes:
+    logger.info("jwt_verifier_key([%s], [%s], [%s]", issuer, discovery_base, idpJWT)
     # We must extract `iss` without validating the JWT,
     # because we need `iss` to know which specific realm endpoint to hit
     # to get the public key we would verify it with
@@ -139,7 +140,7 @@ def jwt_verifier_key(
     # TODO Verify issuer matches oidc_config issuer field
     # TODO Cache jwks_client by uri
     jwks_client = jwt.PyJWKClient(oidc_config["jwks_uri"])
-    jwk = jwks_client.get_signing_key_from_jwt(jwt)
+    jwk = jwks_client.get_signing_key_from_jwt(idpJWT)
     return jwk.key
 
 

--- a/containers/kas/kas_core/tdf3_kas_core/authorized.py
+++ b/containers/kas/kas_core/tdf3_kas_core/authorized.py
@@ -123,7 +123,7 @@ def oidc_discovery(server: str) -> dict:
 def jwt_verifier_key(
     issuer: str, discovery_base: str | None, idpJWT: str | bytes
 ) -> PublicKeyTypes:
-    logger.info("jwt_verifier_key([%s], [%s], [%s]", issuer, discovery_base, idpJWT)
+    logger.debug("jwt_verifier_key([%s], [%s], [%s]", issuer, discovery_base, idpJWT)
     # We must extract `iss` without validating the JWT,
     # because we need `iss` to know which specific realm endpoint to hit
     # to get the public key we would verify it with

--- a/containers/kas/kas_core/tdf3_kas_core/authorized.py
+++ b/containers/kas/kas_core/tdf3_kas_core/authorized.py
@@ -4,12 +4,16 @@ import jwt
 import logging
 import os
 import re
+import requests
 
+from cryptography.hazmat.primitives.asymmetric.types import PublicKeyTypes
 from datetime import datetime, timedelta
 
 from tdf3_kas_core.errors import AuthorizationError
 from tdf3_kas_core.errors import JWTError
 from tdf3_kas_core.errors import UnauthorizedError
+from tdf3_kas_core.keycloak import fetch_realm_key_by_jwt
+from tdf3_kas_core.models.key_master.key_master import KeyMaster
 
 
 logger = logging.getLogger(__name__)
@@ -84,22 +88,7 @@ def looks_like_jwt(jwt):
     return bool(match)
 
 
-def unsafe_decode_jwt(auth_token):
-    try:
-        # grab information out of the token without verifying it.
-        decoded = jwt.decode(
-            # This could be an access_token or refresh_token
-            auth_token,
-            options={"verify_signature": False, "verify_aud": False},
-            algorithms=["RS256", "ES256", "ES384", "ES512"],
-        )
-    except Exception as e:
-        raise UnauthorizedError("Invalid JWT") from e
-
-    return decoded
-
-
-def authorized(public_key, auth_token):
+def authorized(public_key, auth_token) -> bool:
     """Raise error if the public key does not validate the JWT auth_token."""
     try:
         unpack_rs256_jwt(auth_token, public_key)
@@ -108,8 +97,73 @@ def authorized(public_key, auth_token):
         raise AuthorizationError("Not authorized") from e
 
 
-def authorized_v2(public_key, auth_token):
-    decoded = unsafe_decode_jwt(auth_token)
+def oidc_discovery(server: str) -> dict:
+    """Looks up the OIDC Discovery information for the given OpenId provider"""
+    # https://openid.net/specs/openid-connect-discovery-1_0.html
+    cfg_url = f'{server.removesuffix("/")}/.well-known/openid-configuration'
+    r = requests.get(cfg_url, headers={"content-type": "application/json"})
+    if r.status_code == 200:
+        if "application/json" in r.headers["content-type"]:
+            values = r.json()
+        else:
+            logger.warning(
+                "oidc discovery: unrecognized content type [%s] from [%s]",
+                r.headers["content-type"],
+                cfg_url,
+            )
+            raise UnauthorizedError("oidc discovery: unrecognized content type")
+    elif r.status_code >= 400:
+        logger.warning("oidc discovery: [%s] from [%s]", r.status_code, server)
+        raise UnauthorizedError(f"oidc discovery: {r.status_code} from backend")
+    else:
+        raise UnauthorizedError("oidc discovery: network failure")
+    return values
+
+
+def jwt_verifier_key(
+    issuer: str, discovery_base: str | None, idpJWT: str | bytes
+) -> PublicKeyTypes:
+    # We must extract `iss` without validating the JWT,
+    # because we need `iss` to know which specific realm endpoint to hit
+    # to get the public key we would verify it with
+    unverified = jwt.PyJWT().decode_complete(
+        idpJWT, options={"verify_signature": False}
+    )
+    unverified_jwt = unverified["payload"]
+    issuer_url = unverified_jwt["iss"]
+    if issuer != issuer_url:
+        # Fail fast; don't bother with other work if from invalid issuer
+        logger.warning("Issuer mismatch: [%s] should be [%s]", issuer_url, issuer)
+        raise UnauthorizedError("Invalid auth header")
+    oidc_config = oidc_discovery(discovery_base or issuer)
+    # TODO Cache jwks_client by uri
+    jwks_client = jwt.PyJWKClient(oidc_config["jwks_uri"])
+    jwk = jwks_client.get_signing_key_from_jwt(jwt)
+    return jwk.key
+
+
+def _get_keycloak_host():
+    return os.environ.get("OIDC_SERVER_URL")
+
+
+def _get_single_auth_host():
+    return os.environ.get("OIDC_ISSUER_URL")
+
+
+# For compatibility, this can look up a key from the OIDC_ISSUER_URL
+# (single oauth2 host) or via the OIDC_SERVER_URL (multiple 'realms' for keycloak)
+def issuer_verifier_key(id_jwt: str | bytes, key_master: KeyMaster):
+    oidc_host = _get_single_auth_host()
+    if oidc_host:
+        discovery_base = os.environ.get("OIDC_DISCOVERY_BASE_URL")
+        return jwt_verifier_key(oidc_host, discovery_base, id_jwt)
+    keycloak_host = _get_keycloak_host()
+    if keycloak_host:
+        return fetch_realm_key_by_jwt(keycloak_host, id_jwt, key_master)
+    raise UnauthorizedError("Issuer Invalid")
+
+
+def authorized_v2(public_key: PublicKeyTypes, auth_token: str | bytes) -> dict:
     try:
         decoded = jwt.decode(
             auth_token,
@@ -119,6 +173,12 @@ def authorized_v2(public_key, auth_token):
             options={"verify_aud": False},
         )
     except jwt.exceptions.PyJWTError as e:
+        decoded = jwt.decode(
+            # This could be an access_token or refresh_token
+            auth_token,
+            options={"verify_signature": False, "verify_aud": False},
+            algorithms=["RS256", "ES256", "ES384", "ES512"],
+        )
         logger.warning(
             "Unverifiable claims [%s] found in [%s], public_key=[%s]",
             decoded,

--- a/containers/kas/kas_core/tdf3_kas_core/authorized.py
+++ b/containers/kas/kas_core/tdf3_kas_core/authorized.py
@@ -136,6 +136,7 @@ def jwt_verifier_key(
         logger.warning("Issuer mismatch: [%s] should be [%s]", issuer_url, issuer)
         raise UnauthorizedError("Invalid auth header")
     oidc_config = oidc_discovery(discovery_base or issuer)
+    # TODO Verify issuer matches oidc_config issuer field
     # TODO Cache jwks_client by uri
     jwks_client = jwt.PyJWKClient(oidc_config["jwks_uri"])
     jwk = jwks_client.get_signing_key_from_jwt(jwt)

--- a/containers/kas/kas_core/tdf3_kas_core/authorized_test.py
+++ b/containers/kas/kas_core/tdf3_kas_core/authorized_test.py
@@ -54,11 +54,6 @@ def test_authorized_fail(entity_private_key, public_key):
         authorized.authorized(public_key, auth_token)
 
 
-def test_jwt_utilities_unsafe_decode_jwt_fails_on_malformed_jwt():
-    with pytest.raises(UnauthorizedError):
-        assert authorized.unsafe_decode_jwt(slightly_borked_jwt)
-
-
 def test_jwt_utilities_rs256test_happy(private_key, public_key):
     """Test creation/validation of asymmetric JWTs with RSA key pairs."""
     expected = {"foo": "bar"}

--- a/containers/kas/kas_core/tdf3_kas_core/conftest.py
+++ b/containers/kas/kas_core/tdf3_kas_core/conftest.py
@@ -9,6 +9,8 @@ import pytest
 import json
 import base64
 
+from jwt.algorithms import RSAAlgorithm
+
 from .models import Policy
 from .models import Entity
 from .models import EntityAttributes
@@ -86,6 +88,14 @@ def public_key():
 @pytest.fixture
 def private_key():
     return __private_key
+
+
+@pytest.fixture
+def public_key_jwk_sig(public_key):
+    jwk = json.loads(RSAAlgorithm.to_jwk(public_key))
+    jwk["use"] = "sig"
+    jwk["kid"] = "a"
+    return jwk
 
 
 @pytest.fixture

--- a/containers/kas/kas_core/tdf3_kas_core/dpop.py
+++ b/containers/kas/kas_core/tdf3_kas_core/dpop.py
@@ -1,3 +1,4 @@
+import os
 import connexion
 import json
 import logging
@@ -8,9 +9,8 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from jwt import PyJWK, PyJWS, PyJWT
 
-from .authorized import authorized_v2, looks_like_jwt
+from .authorized import authorized_v2, issuer_verifier_key, looks_like_jwt
 from .errors import UnauthorizedError
-from .keycloak import fetch_realm_key_by_jwt
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +60,7 @@ def validate_dpop(dpop, key_master, request=connexion.request, do_oidc=False):
     Returns False if either DPoP is ignored or no auth is requested.
     """
     auth_header = request.headers.get("authorization", None)
-    
+
     if not auth_header:
         if do_oidc:
             raise UnauthorizedError("Missing auth header")
@@ -72,7 +72,7 @@ def validate_dpop(dpop, key_master, request=connexion.request, do_oidc=False):
         if do_oidc:
             raise UnauthorizedError("Invalid auth header")
         return False
-    verifier_key = fetch_realm_key_by_jwt(id_jwt, key_master)
+    verifier_key = issuer_verifier_key(id_jwt, key_master)
     jwt_decoded = authorized_v2(verifier_key, id_jwt)
     logger.debug("jwt_decoded: [%s]", jwt_decoded)
     cnf = jwt_decoded.get("cnf", None)
@@ -125,7 +125,9 @@ def validate_dpop(dpop, key_master, request=connexion.request, do_oidc=False):
     # workaround for starlette request.url not including ingress path
     htu_no_ingress = htu.replace("/api/kas", "")
     if m != htm or u != htu_no_ingress:
-        logger.warning("Invalid DPoP htm:[%s] htu:[%s] != m:[%s] u[%s]", htm, htu_no_ingress, m, u)
+        logger.warning(
+            "Invalid DPoP htm:[%s] htu:[%s] != m:[%s] u[%s]", htm, htu_no_ingress, m, u
+        )
         raise UnauthorizedError("Invalid DPoP")
     access_token_hash = jws_sha(id_jwt)
     if ath != access_token_hash:

--- a/containers/kas/kas_core/tdf3_kas_core/kas.py
+++ b/containers/kas/kas_core/tdf3_kas_core/kas.py
@@ -2,7 +2,14 @@
 
 import os
 import connexion
-from connexion.options import ConnexionOptions
+
+try:
+    from connexion.options import ConnexionOptions
+except ImportError:
+    from connextion.options import SwaggerUIOptions
+
+    ConnexionOptions = SwaggerUIOptions
+
 import importlib_resources
 import logging
 import urllib.parse

--- a/containers/kas/kas_core/tdf3_kas_core/kas.py
+++ b/containers/kas/kas_core/tdf3_kas_core/kas.py
@@ -2,7 +2,7 @@
 
 import os
 import connexion
-from connexion.options import SwaggerUIOptions
+from connexion.options import ConnexionOptions
 import importlib_resources
 import logging
 import urllib.parse
@@ -361,12 +361,11 @@ class Kas(object):
 
         self._session_kas_public_key = create_session_public_key(self._key_master)
 
-        swagger_ui_options = SwaggerUIOptions(
-            swagger_ui_path="/docs",
-            swagger_ui=False
-        )
+        swagger_ui_options = ConnexionOptions(swagger_ui_path="/docs", swagger_ui=False)
         app = connexion.FlaskApp(
-            self._root_name, specification_dir="api/", swagger_ui_options=swagger_ui_options
+            self._root_name,
+            specification_dir="api/",
+            swagger_ui_options=swagger_ui_options,
         )
 
         # swagger_ui default disabled
@@ -377,7 +376,7 @@ class Kas(object):
 
             proxied = ReverseProxied(flask_app.wsgi_app, script_name="/api/kas/")
             flask_app.wsgi_app = proxied
-            swagger_ui_options = SwaggerUIOptions(
+            swagger_ui_options = ConnexionOptions(
                 swagger_ui_path="/docs",
                 swagger_ui=True,
                 swagger_ui_template_dir=swagger_ui_4_path,
@@ -387,7 +386,9 @@ class Kas(object):
 
         # Connexion will link REST endpoints to handlers using the openapi.yaml file
         openapi_file = importlib_resources.files(__package__) / "api" / "openapi.yaml"
-        app.add_api(openapi_file, swagger_ui_options=swagger_ui_options, strict_validation=True)
+        app.add_api(
+            openapi_file, swagger_ui_options=swagger_ui_options, strict_validation=True
+        )
 
         logger.debug("KAS app starting.")
         # convert from asgi to wsgi

--- a/containers/kas/kas_core/tdf3_kas_core/kas.py
+++ b/containers/kas/kas_core/tdf3_kas_core/kas.py
@@ -6,7 +6,7 @@ import connexion
 try:
     from connexion.options import ConnexionOptions
 except ImportError:
-    from connextion.options import SwaggerUIOptions
+    from connexion.options import SwaggerUIOptions
 
     ConnexionOptions = SwaggerUIOptions
 

--- a/containers/kas/kas_core/tdf3_kas_core/keycloak.py
+++ b/containers/kas/kas_core/tdf3_kas_core/keycloak.py
@@ -2,26 +2,19 @@
 
 import os
 import logging
+import jwt
 import requests
 from cryptography import hazmat
+from cryptography.hazmat.primitives.asymmetric.types import PublicKeyTypes
 from urllib.parse import urlparse
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
-from tdf3_kas_core.errors import KeyNotFoundError
-from tdf3_kas_core.errors import AuthorizationError
+from tdf3_kas_core.errors import KeyNotFoundError, UnauthorizedError
 
-from tdf3_kas_core.authorized import unsafe_decode_jwt
+from tdf3_kas_core.models.key_master.key_master import KeyMaster
 
 logger = logging.getLogger(__name__)
-
-
-def _get_keycloak_host():
-    kc_host = os.environ.get("OIDC_SERVER_URL")
-    if not kc_host:
-        raise AuthorizationError("OIDC_SERVER_URL not set! Can't fetch keys")
-
-    return kc_host
 
 
 def get_retryable_request():
@@ -50,9 +43,8 @@ def get_retryable_request():
 #     ).json()
 #     jwks_client = PyJWKClient(oidc_config["jwks_uri"])
 #     return jwks_client.get_signing_key_from_jwt(jwt)
-def get_keycloak_public_key(realmId):
-    KEYCLOAK_HOST = _get_keycloak_host()
-    url = f"{KEYCLOAK_HOST}/auth/realms/{realmId}"
+def get_keycloak_public_key(host: str, realmId: str) -> PublicKeyTypes:
+    url = f"{host}/auth/realms/{realmId}"
 
     http = get_retryable_request()
 
@@ -109,13 +101,13 @@ def try_extract_realm(unverified_jwt):
 # For now, we're relying on key_master to handle caching, and just using
 # a cached pubkey if one exists - this (and key_master itself) could stand to be
 # more robust in terms of key validity checks, rotations, refreshes, etc.
-def load_realm_key(realmId, key_master):
+def load_realm_key(host: str, realmId: str, key_master: KeyMaster) -> PublicKeyTypes:
     realmKey = {}
     try:
         realmKey = key_master.public_key(f"KEYCLOAK-PUBLIC-{realmId}")
     except KeyNotFoundError:
         try:
-            realmKey = get_keycloak_public_key(realmId)
+            realmKey = get_keycloak_public_key(host, realmId)
         except Exception:
             logger.warning(
                 f"Unable to fetch public key for realm: {realmId} from Keycloak endpoint",
@@ -130,11 +122,18 @@ def load_realm_key(realmId, key_master):
 # Given a JWT and the keymaster, attempt to obtain the right pubkey from
 # Keycloak for the realm this JWT was issued from.
 # If anything goes wrong, return an empty/falsy value
-def fetch_realm_key_by_jwt(idpJWT, key_master):
+def fetch_realm_key_by_jwt(host: str, idpJWT, key_master: KeyMaster) -> PublicKeyTypes:
     # We must extract `iss` without validating the JWT,
     # because we need `iss` to know which specific realm endpoint to hit
     # to get the public key we would verify it with
-    unverified_jwt = unsafe_decode_jwt(idpJWT)
+    try:
+        unverified_jwt = jwt.decode(
+            idpJWT,
+            options={"verify_signature": False, "verify_aud": False},
+            algorithms=["RS256", "ES256", "ES384", "ES512"],
+        )
+    except Exception as e:
+        raise UnauthorizedError("Invalid JWT") from e
 
     realmId = ""
     # If we can't parse or extract the realm ID from the issuer JWT
@@ -147,4 +146,4 @@ def fetch_realm_key_by_jwt(idpJWT, key_master):
         )
         return None
 
-    return load_realm_key(realmId, key_master)
+    return load_realm_key(host, realmId, key_master)

--- a/containers/kas/kas_core/tdf3_kas_core/keycloak_test.py
+++ b/containers/kas/kas_core/tdf3_kas_core/keycloak_test.py
@@ -99,22 +99,9 @@ def mocked_requests_get_fails(*args, **kwargs):
 
 
 @patch("requests.Session.get", side_effect=mocked_requests_get)
-def test_get_keycloak_public_key_fails_without_required_env(mock_get):
-    """Tests that fetching KC pubkey, but without crucial
-    env vars set, will raise."""
-    with pytest.raises(Exception, match=r"OIDC_SERVER_URL"):
-        del os.environ["OIDC_SERVER_URL"]
-        keycloak.get_keycloak_public_key("tdf")
-    # Should bail before it makes a request if the env vars aren't set.
-    assert mock_get.called == False
-
-
-@patch("requests.Session.get", side_effect=mocked_requests_get)
 def test_get_keycloak_public_key_succeeds_with_required_env(mock_get):
-    """Tests that fetching KC pubkey, but with crucial
-    env vars set, will fetch pubkey."""
-    os.environ["OIDC_SERVER_URL"] = "https://mykc.com"
-    pubkey = keycloak.get_keycloak_public_key("tdf")
+    """Tests that fetching KC pubkey will invoke an http get pubkey."""
+    pubkey = keycloak.get_keycloak_public_key("https://mykc.com", "tdf")
     assert mock_get.called == True
     assert pubkey
 
@@ -129,8 +116,7 @@ def test_try_extract_realm_returns_realmkey(mock_get):
 @patch("requests.Session.get", side_effect=mocked_requests_get)
 def test_load_realm_key_prefers_cached_key(mock_get, key_master):
     realm = "tdf"
-    os.environ["OIDC_SERVER_URL"] = "https://mykc.com"
-    realmKey = keycloak.load_realm_key(realm, key_master)
+    realmKey = keycloak.load_realm_key("https://mykc.com", realm, key_master)
     assert mock_get.called == False
     assert realmKey
 
@@ -138,8 +124,7 @@ def test_load_realm_key_prefers_cached_key(mock_get, key_master):
 @patch("requests.Session.get", side_effect=mocked_requests_get)
 def test_load_realm_key_fetches_uncached_key(mock_get, key_master):
     realm = "someRealm"
-    os.environ["OIDC_SERVER_URL"] = "https://mykc.com"
-    realmKey = keycloak.load_realm_key(realm, key_master)
+    realmKey = keycloak.load_realm_key("https://mykc.com", realm, key_master)
     assert mock_get.called == True
     assert realmKey
 
@@ -148,7 +133,6 @@ def test_load_realm_key_fetches_uncached_key(mock_get, key_master):
 def test_uncached_key_fetch_fails_returns_falsy_empty(mock_get, key_master):
     realm = "someRealm"
     realmKey = ""
-    os.environ["OIDC_SERVER_URL"] = "https://mykc.com"
-    realmKey = keycloak.load_realm_key(realm, key_master)
+    realmKey = keycloak.load_realm_key("https://mykc.com", realm, key_master)
     assert mock_get.called == True
     assert not realmKey

--- a/containers/kas/kas_core/tdf3_kas_core/models/attribute_policies/attribute_policy_cache.py
+++ b/containers/kas/kas_core/tdf3_kas_core/models/attribute_policies/attribute_policy_cache.py
@@ -28,7 +28,7 @@ class AttributePolicyCache(object):
     def load_config(self, attribute_policy_config):
         """Load policies defined in a config dict."""
         if not attribute_policy_config:
-            logger.warn("No attribute configs found")
+            logger.warning("No attribute configs found")
             return
         logger.debug(
             "--- Fetch attribute_policy_config  [attribute = %s] ---",

--- a/containers/kas/kas_core/tdf3_kas_core/pdp_grpc.py
+++ b/containers/kas/kas_core/tdf3_kas_core/pdp_grpc.py
@@ -16,7 +16,7 @@ HIERARCHY = "hierarchy"
 def convert_attribute_defs(attribute_defs):
     """Load attribute definitions from a dict."""
     if not attribute_defs:
-        logger.warn("No attribute definitions found!")
+        logger.warning("No attribute definitions found!")
         return
     logger.debug(
         "--- attribute definitions  [attribute def = %s] ---",
@@ -62,7 +62,7 @@ def convert_attribute_defs(attribute_defs):
 def convert_entity_attrs(entity_attributes):
     """Load attribute instances from a dict."""
     if not entity_attributes:
-        logger.warn("No entity attributes found!")
+        logger.warning("No entity attributes found!")
         return
     logger.debug(
         "--- entity attribute instances  [attribute instances = %s] ---",
@@ -91,7 +91,7 @@ def convert_entity_attrs(entity_attributes):
 def convert_data_attrs(data_attributes):
     """Load attribute instances from a dict."""
     if not data_attributes:
-        logger.warn("No data attributes found!")
+        logger.warning("No data attributes found!")
         return
     logger.debug(
         "--- data attribute instances  [attribute instances = %s] ---",

--- a/containers/kas/kas_core/tdf3_kas_core/services.py
+++ b/containers/kas/kas_core/tdf3_kas_core/services.py
@@ -68,6 +68,7 @@ from tdf3_kas_core.models.nanotdf import SymmetricAndPayloadConfig
 
 from tdf3_kas_core.authorized import authorized
 from tdf3_kas_core.authorized import authorized_v2
+from tdf3_kas_core.authorized import issuer_verifier_key
 from tdf3_kas_core.authorized import looks_like_jwt
 from tdf3_kas_core.authorized import leeway
 
@@ -255,7 +256,7 @@ def _decode_and_validate_oidc_jwt(context, key_master):
     realmKey = (
         key_master.public_key("AA-PUBLIC")
         if (context.has("X-Tdf-Claims") and os.environ.get("V2_SAAS_ENABLED"))
-        else keycloak.fetch_realm_key_by_jwt(idpJWT, key_master)
+        else issuer_verifier_key(idpJWT, key_master)
     )
     return authorized_v2(realmKey, idpJWT)
 

--- a/xtest.Tiltfile
+++ b/xtest.Tiltfile
@@ -7,7 +7,7 @@ load("./common.Tiltfile", "backend", "CONTAINER_REGISTRY", "OIDC_CLIENT_SECRET")
 backend(
     set={
         "kas.ingress.enabled": "true",
-        'kas.auth."http://localhost:65432/auth/realms/tdf".clientId': "tdf-access",
+        "kas.auth.http://localhost:65432/auth/realms/tdf.discoveryBaseUrl": "http://keycloak-http/auth/realms/tdf",
     }
 )
 

--- a/xtest.Tiltfile
+++ b/xtest.Tiltfile
@@ -7,6 +7,7 @@ load("./common.Tiltfile", "backend", "CONTAINER_REGISTRY", "OIDC_CLIENT_SECRET")
 backend(
     set={
         "kas.ingress.enabled": "true",
+        'kas.auth."http://localhost:65432/auth/realms/tdf".clientId': "tdf-access",
     }
 )
 


### PR DESCRIPTION
### Proposed Changes

- Lets KAS chart generate `OIDC_ISSUER_URL` and `OIDC_DISCOVERY_BASE_URL` if set in the `auth` value
- Updates python KAS container to respect these values
- This lets KAS support other OIDC providers, instead of relying on keycloak specifically. This means we don't get multi-realm support, and instead must pick a single realm provider

### Checklist

- [x] I have added or updated unit tests and run them via `scripts/monotest all`
- [x] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [x] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
