### PR TITLE
✨ Lets a helm installer extend the KAS configmap

### DIFF
--- a/charts/kas/templates/configmap.yaml
+++ b/charts/kas/templates/configmap.yaml
@@ -51,3 +51,7 @@ data:
 
   # OpenAPI test user interface
   SWAGGER_UI: {{ .Values.swaggerUIEnabled | quote }}
+
+  {{- with .Values.extraConfigMapData }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}

--- a/charts/kas/values.yaml
+++ b/charts/kas/values.yaml
@@ -203,3 +203,6 @@ readinessProbe:
   httpGet:
     path: /healthz?probe=readiness
     port: http
+
+# -- Inlined into the ConfigMap, if present.
+extraConfigMapData:

--- a/tests/containers/clients/Dockerfile
+++ b/tests/containers/clients/Dockerfile
@@ -19,12 +19,8 @@ RUN apt-get update || : && apt-get -y install \
   gnupg \
   jq
 RUN mkdir -p /etc/apt/keyrings
-RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
-    | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_VERSION}.x nodistro main" \
-    | tee /etc/apt/sources.list.d/nodesource.list
-RUN apt-get update
-RUN apt-get install -y nodejs
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - &&\
+  apt-get install -y nodejs
 RUN npm install -g npm
 RUN python3 --version && pip3 --version && node --version && npm --version
 

--- a/tests/performance-test/Dockerfile
+++ b/tests/performance-test/Dockerfile
@@ -1,6 +1,8 @@
 ARG PY_TEST_VERSION=3.8
 FROM python:${PY_TEST_VERSION}
-RUN apt-get update || : && apt-get install curl jq -y
+RUN apt-get update || : && apt-get -y install \
+    curl \
+    jq
 RUN pip3 install --upgrade pip
 # test
 WORKDIR /test/


### PR DESCRIPTION
### Proposed Changes

Adds a new Value to the kas configmap which is a JSON blob stapled to the end of the KAS configmap, if present. This will allow custom environment variables to be set when using odd or custom KAS images

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

### Testing Instructions
