### PR TITLE
Add a docstring to the keycloak_bootstrap module.

### DIFF
--- a/containers/keycloak-bootstrap/keycloak_bootstrap.py
+++ b/containers/keycloak-bootstrap/keycloak_bootstrap.py
@@ -987,6 +987,14 @@ def configureKeycloak(kc_admin_user, kc_admin_pass, kc_url, keycloak_config):
 
 
 def kc_bootstrap():
+    """
+    This function provides a mechanism to hydrate Keycloak's configuration. 
+    
+    Users of the keycloak-bootstrap may either provide a `clients` & `users` section
+    OR provide a `customConfig` object in Helm values. NOTE: When using `customConfig`, 
+    ALL users and clients must be defined (the `clients` & `users` sections will be 
+    ignored when `customConfig` is given).
+    """
     logger.info("Running Keycloak bootstrap")
     username = os.getenv("keycloak_admin_username")
     password = os.getenv("keycloak_admin_password")


### PR DESCRIPTION
### Proposed Changes

Hello 👋 ,

Recently, I was looking at the use of a Helm configuration value `customConfig`, which is used in Keycloak Bootstrapping.  As I wasn't familiar with it previously, I went looking for an exact match for the string `customConfig`, and found it in these files:

1. https://github.com/opentdf/opentdf/blob/1.5.0/examples/helm/values-bootstrap.yaml#L5
2. https://github.com/opentdf/backend/blob/1.5.0/charts/backend/values.yaml#L340-L354
3. https://github.com/opentdf/backend/blob/1.5.0/charts/keycloak-bootstrap/values.yaml#L66-L70
4. https://github.com/opentdf/backend/blob/1.5.0/charts/keycloak-bootstrap/templates/bootstrap-configmap.yaml#L8-L10

I believe this is used here: https://github.com/opentdf/backend/blob/1.5.0/containers/keycloak-bootstrap/keycloak_bootstrap.py#L997-L998 .  However, I was uncertain because I didn't find `customConfig` used or mentioned (exactly) in the file.  

I believe the `keycloak_bootstrap.py` module takes `customConfig` from the mapped YAML file and parses it into the `bootstrap_config` variable, which then gets used to hydrate Keycloak's configuration.

Would you oppose a Pull Request which adds a docstring to the `kc_bootstrap` function and repeats this sort of statement?

Example `kc_bootstrap` docstring: 

```python
def kc_bootstrap():
    """
    This function provides a mechanism to hydrate Keycloak's configuration. 
    
    Users of the keycloak-bootstrap may either provide a `clients` & `users` section
    OR provide a `customConfig` object in Helm values. NOTE: When using `customConfig`, 
    ALL users and clients must be defined (the `clients` & `users` sections will be 
    ignored when `customConfig` is given).
    """
    ...
```

It's an incredibly small update, but my hope is that this can help with the projects health & Developer Experience (see https://github.blog/2024-01-23-good-devex-increases-productivity/ ) .

### Checklist

- [ ] I have added or updated unit tests and run them via `scripts/monotest all`
- [ ] I have added or updated E2E cluster tests and run them via `tilt -f xtest.Tiltfile`
- [ ] I have added or updated integration tests in `tests/integration` (if appropriate)
- [x] I have added or updated documentation / readme (if appropriate)
   - ⭐ _**In a way**_ (_this PR only introduces a docstring_) 
- [ ] I have verified that my changes have not introduced new lint errors
- [ ] I have updated the change log

